### PR TITLE
feat: Add column visibility selector to DynamicTable

### DIFF
--- a/Dynamic-table/demo_full.html
+++ b/Dynamic-table/demo_full.html
@@ -115,11 +115,11 @@
         { "productName": "Organic Cotton T-Shirt", "category": "Apparel", "price": 29.95, "popularityChart": { "labels": ["W1","W2","W3"], "datasets":[{"values":[7,7,9], "backgroundColor":"#4BC0C0"}] } } // productName, category translated
       ],
       "userData": [
-        { "id": 1, "firstName": "Alice", "lastName": "Martin", "email": "alice.martin@example.com", "registrationDate": "2023-01-15" },
-        { "id": 2, "firstName": "Bob", "lastName": "Durand", "email": "bob.durand@example.com", "registrationDate": "2023-02-20" },
-        { "id": 3, "firstName": "Carla", "lastName": "Petit", "email": "carla.petit@example.com", "registrationDate": "2022-11-05" },
-        { "id": 4, "firstName": "David", "lastName": "Leroy", "email": "david.leroy@example.com", "registrationDate": "2023-05-10" },
-        { "id": 5, "firstName": "Eva", "lastName": "Moreau", "email": "eva.moreau@example.com", "registrationDate": "2022-07-19" }
+        { "id": 1, "firstName": "Alice", "lastName": "Martin", "email": "alice.martin@example.com", "registrationDate": "2023-01-15", "ip_address": "192.168.1.101" },
+        { "id": 2, "firstName": "Bob", "lastName": "Durand", "email": "bob.durand@example.com", "registrationDate": "2023-02-20", "ip_address": "192.168.1.102" },
+        { "id": 3, "firstName": "Carla", "lastName": "Petit", "email": "carla.petit@example.com", "registrationDate": "2022-11-05", "ip_address": "192.168.1.103" },
+        { "id": 4, "firstName": "David", "lastName": "Leroy", "email": "david.leroy@example.com", "registrationDate": "2023-05-10", "ip_address": "192.168.1.104" },
+        { "id": 5, "firstName": "Eva", "lastName": "Moreau", "email": "eva.moreau@example.com", "registrationDate": "2022-07-19", "ip_address": "192.168.1.105" }
       ]
     };
 
@@ -235,7 +235,8 @@
                     { key: 'id', header: 'ID', sortable: true },
                     { key: 'firstName', header: 'First Name', sortable: true, filterable: true }, // Translated
                     { key: 'lastName', header: 'Last Name', sortable: true, filterable: true }, // Translated
-                    { key: 'email', header: 'Email' },
+                    { key: 'email', header: 'Email', visible: false },
+                    { key: 'ip_address', header: 'IP Address', visible: false },
                     { key: 'registrationDate', header: 'Registration', format: 'date:YYYY/MM/DD', sortable: true } // Translated
                 ],
                 rowsPerPage: 5,

--- a/Dynamic-table/dynamic-table.css
+++ b/Dynamic-table/dynamic-table.css
@@ -296,7 +296,9 @@
         align-items: stretch;
     }
     .dynamic-table-controls input[type="search"],
-    .dynamic-table-controls .dt-common-select { /* Targets the common class for filters */
+    .dynamic-table-controls .dt-common-select, /* Targets the common class for filters */
+    .dynamic-table-controls .dt-custom-select, /* Ensure custom selects also go full width */
+    .dynamic-table-controls .dt-column-selector-button { /* Ensure new button also goes full width */
         min-width: 0;
         width: 100%;
     }
@@ -429,4 +431,95 @@
 }
 .dt-custom-select.open .dt-custom-options { /* Class 'open' will be toggled by JS */
     display: block;
+}
+
+
+/* === Column Visibility Selector Styles === */
+.dynamic-table-column-selector {
+    position: relative; /* For positioning the dropdown */
+    /* No specific min-width, it will be defined by its content (button) */
+}
+
+.dt-column-selector-button {
+    padding: 8px 12px; /* Similar to search input and common select */
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: #fff;
+    color: #555; /* Standard text color for controls */
+    cursor: pointer;
+    font-size: 1rem; /* Match other controls */
+    font-family: inherit; /* Ensure font consistency */
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dt-column-selector-button:hover {
+    border-color: #aaa;
+}
+
+.dt-column-selector-button:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.dt-column-selector-dropdown {
+    position: absolute;
+    top: 100%; /* Position below the button */
+    left: 0; 
+    /* If the button might be close to the right edge, 'right: 0;' might be better,
+       or JS positioning. For now, left: 0 is standard. */
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-top-color: #ddd; /* Slightly lighter top border for separation */
+    border-radius: 0 0 4px 4px; /* Rounded bottom corners */
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    z-index: 1050; /* Higher than sticky header and custom flag dropdown */
+    min-width: 200px; /* Ensure a reasonable width */
+    max-height: 250px; /* Limit height for long lists */
+    overflow-y: auto;
+    padding: 5px 0; /* Padding top/bottom for the list */
+    /* display: none; is handled by JS inline style */
+}
+
+.dt-column-selector-item {
+    padding: 8px 12px;
+    display: block; /* Make the whole item area clickable if label wraps input */
+}
+
+.dt-column-selector-item:hover {
+    background-color: #f0f5f8; /* Consistent hover color */
+}
+
+.dt-column-selector-item label {
+    display: flex; /* Align checkbox and text */
+    align-items: center;
+    font-weight: normal; /* Override general label bolding if any */
+    font-size: 0.95rem; /* Slightly smaller for dropdown items */
+    color: #333;
+    cursor: pointer;
+    margin-bottom: 0; /* Reset from general label style */
+}
+
+.dt-column-selector-item input[type="checkbox"] {
+    margin-right: 8px; /* Space between checkbox and label text */
+    cursor: pointer;
+    /* Consider custom styling for checkboxes for better cross-browser consistency if needed */
+}
+
+/* Responsive adjustments for the column selector dropdown */
+@media (max-width: 768px) {
+    .dynamic-table-column-selector {
+        width: 100%; /* Make the container full width if button is full width */
+    }
+    /* The button .dt-column-selector-button is already set to width: 100% in the main responsive block */
+    
+    .dt-column-selector-dropdown {
+        width: 100%; /* Dropdown can also be full width or adapt */
+        /* Or, if preferred, it can remain a fixed width but might require JS to position
+           if it would overflow the screen. Full width is often simpler on mobile. */
+        min-width: 0; /* Override min-width for full-width behavior */
+        left: 0;
+        right: 0; /* Ensure it spans full width if parent is full width */
+        box-sizing: border-box;
+    }
 }


### PR DESCRIPTION
This commit introduces a new feature to the DynamicTable component that allows you to select which columns to display or hide.

Key changes:

-   **Column Configuration:** Added a `visible` property (boolean, defaults to `true`) to the column definition in `config.columns` to control initial visibility.
-   **Column Selector UI:**
    -   A "Select Columns" button is added to the table controls.
    -   Clicking this button reveals a dropdown menu with checkboxes for each column.
    -   You can toggle column visibility in real-time.
-   **Rendering Logic:**
    -   The table header and body now dynamically render only the visible columns.
    -   Colspan for messages (loading, no results) adjusts to the number of visible columns.
-   **CSS:** Added styles for the column selector button and dropdown to match the existing table theme.
-   **Demo:** Updated `demo_full.html` to showcase initial column hiding and the selector functionality.

This feature enhances table usability by giving you control over the displayed data fields without affecting underlying data operations like sorting and filtering.