### PR TITLE
refactor: Adjust controls bar layout for specific element order

### DIFF
--- a/Dynamic-table/dynamic-table.css
+++ b/Dynamic-table/dynamic-table.css
@@ -42,20 +42,11 @@
     border-bottom: 1px solid #e0e0e0; /* Visual separator */
 }
 
-/* Order for control elements */
-.dynamic-table-search-control {
-    order: 1;
-}
-.dynamic-table-filter-control {
-    order: 2;
-}
-.dynamic-table-results-info {
-    order: 3;
-}
-.dynamic-table-column-selector { /* Wrapper for the gear icon button and its dropdown */
-    order: 4;
-    /* margin-left: auto; is already applied from a previous step to push it right */
-}
+/* Order for control elements - REMOVED */
+/* .dynamic-table-search-control { order: 1; } */
+/* .dynamic-table-filter-control { order: 2; } */
+/* .dynamic-table-results-info { order: 3; } */
+/* .dynamic-table-column-selector { order: 4; } */
 
 
 .dynamic-table-controls label {
@@ -84,7 +75,7 @@
     font-size: 0.9rem;
     color: #555;
     text-align: right;
-    /* margin-left: auto; */ /* Removed to allow column selector to be on the far right */
+    /* margin-left: auto; */ /* This is now handled by the right-controls-group */
     padding-bottom: 8px; /* Align with input bottoms if align-items: flex-end is on parent */
 }
 .dynamic-table-results-info strong {
@@ -481,9 +472,16 @@
 /* === Column Visibility Selector Styles === */
 .dynamic-table-column-selector {
     position: relative; /* For positioning the dropdown */
-    margin-left: auto; /* Pushes the column selector to the far right, works with order */
+    /* margin-left: auto; /* REMOVED - Now handled by parent group */ */
     /* No specific min-width, it will be defined by its content (button) */
-    /* order: 4; is now defined above with other control elements */
+}
+
+/* Group for right-aligned controls */
+.dynamic-table-right-controls-group {
+    margin-left: auto; /* This pushes the whole group to the right */
+    display: flex;
+    align-items: center; 
+    gap: 15px; /* Match parent gap for consistency */
 }
 
 .dt-column-selector-button {

--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -248,8 +248,8 @@ function createDynamicTable(config) {
         
         // Add Column Selector to controls
         columnSelectorWrapper = buildColumnSelector(); // buildColumnSelector is now defined
-        controlsWrapper.appendChild(columnSelectorWrapper);
-        hasVisibleTopControls = true; // Assuming we always show it if columns exist
+        // controlsWrapper.appendChild(columnSelectorWrapper); // Will be added to rightControlsGroup
+        // hasVisibleTopControls = true; // Will be set if rightControlsGroup is added or other controls
 
         columns.forEach(col => {
             if (col.filterable && col.key) {
@@ -318,15 +318,29 @@ function createDynamicTable(config) {
             }
         });
         
+        // Create a group for right-aligned controls
+        const rightControlsGroup = document.createElement('div');
+        rightControlsGroup.className = 'dynamic-table-right-controls-group';
+        let hasRightControls = false;
+
         if (showResultsCount) {
              const resultsDiv = document.createElement('div');
              resultsDiv.className = 'dynamic-table-results-info';
              resultsCountSpan = document.createElement('strong');
              resultsCountSpan.textContent = '0';
              resultsDiv.appendChild(resultsCountSpan);
-             resultsDiv.appendChild(document.createTextNode(' result(s)')); // Translated
-             controlsWrapper.appendChild(resultsDiv);
-             hasVisibleTopControls = true;
+             resultsDiv.appendChild(document.createTextNode(' result(s)'));
+             rightControlsGroup.appendChild(resultsDiv); // Append to group
+             hasRightControls = true;
+        }
+
+        // Always add column selector to the right group
+        rightControlsGroup.appendChild(columnSelectorWrapper);
+        hasRightControls = true;
+        
+        if (hasRightControls) {
+            controlsWrapper.appendChild(rightControlsGroup);
+            hasVisibleTopControls = true;
         }
         
         if (hasVisibleTopControls) {


### PR DESCRIPTION
This commit refines the layout of the table controls bar:

- Global Search and Filter dropdowns are aligned to the left.
- A new right-aligned group contains the Results Count and the Column Visibility Selector icon.
- Within this right group, the Results Count appears to the left of the Column Visibility Selector.

This is achieved by:
- Modifying `buildTableShell` in `dynamic-table.js` to create a wrapper div for the right-aligned elements.
- Adjusting CSS in `dynamic-table.css` to apply `margin-left: auto` to this new wrapper group and style its flex properties for correct internal alignment and spacing.
- Removing previous CSS `order` properties, as the new HTML structure and flexbox handle the layout.