### PR TITLE
feat: Add option to hide column visibility selector

### DIFF
--- a/Dynamic-table/demo_full.html
+++ b/Dynamic-table/demo_full.html
@@ -187,7 +187,8 @@
                 showSearchControl: true,
                 showResultsCount: true,
                 showPagination: true, 
-                showRowsPerPageSelector: true, 
+                showRowsPerPageSelector: true,
+                // showColumnVisibilitySelector: true, // Default, so omitted for this table
                 tableMaxHeight: '350px',
                 defaultSortColumn: 'name',
                 defaultSortDirection: 'asc'
@@ -222,6 +223,7 @@
                 showSearchControl: false,
                 showResultsCount: false,
                 showPagination: false,
+                showColumnVisibilitySelector: false, // Demonstrate hiding the selector
             });
         } else {
              document.getElementById('table-products-minimal').innerHTML = '<p>"productData" not found.</p>'; // Translated
@@ -245,6 +247,7 @@
                 defaultSortColumn: 'lastName',
                 showPagination: true,
                 showRowsPerPageSelector: false,
+                showColumnVisibilitySelector: true, // Demonstrate explicitly showing (though it's the default)
             });
         } else {
             document.getElementById('table-users-classic').innerHTML = '<p>"userData" not found.</p>'; // Translated

--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -64,7 +64,8 @@ function createDynamicTable(config) {
         showRowsPerPageSelector = true,
         rowsPerPageOptions = [10, 25, 50, 100, 'All'], // Default 'Tout' changed to 'All'
         tableMaxHeight = null,
-        uniformChartHeight = null
+        uniformChartHeight = null,
+        showColumnVisibilitySelector = true // New configuration option
     } = config;
 
     let initialRowsPerPageSetting = config.rowsPerPage !== undefined ? config.rowsPerPage : (rowsPerPageOptions[0] || 10);
@@ -335,12 +336,18 @@ function createDynamicTable(config) {
         }
 
         // Always add column selector to the right group
-        rightControlsGroup.appendChild(columnSelectorWrapper);
-        hasRightControls = true;
+        // rightControlsGroup.appendChild(columnSelectorWrapper); // Made conditional below
+        // hasRightControls = true; // Will be set if column selector is added
+
+        if (showColumnVisibilitySelector) {
+            columnSelectorWrapper = buildColumnSelector(); // Ensure it's created if shown
+            rightControlsGroup.appendChild(columnSelectorWrapper);
+            hasRightControls = true;
+        }
         
-        if (hasRightControls) {
+        if (hasRightControls) { // Only append the group if it has children
             controlsWrapper.appendChild(rightControlsGroup);
-            hasVisibleTopControls = true;
+            hasVisibleTopControls = true; // If right group has controls, then top controls are visible
         }
         
         if (hasVisibleTopControls) {


### PR DESCRIPTION
This commit introduces a new configuration option `showColumnVisibilitySelector` (defaulting to `true`) for the `createDynamicTable` function.

When `showColumnVisibilitySelector` is set to `false`, the gear icon button that allows you to toggle column visibility will not be displayed in the table's control bar.

This provides you with more control over the table's UI complexity, allowing you to disable this feature if it's not needed for a particular table instance.

The `buildTableShell` function has been updated to conditionally render the column selector UI based on this new option. The demo file (`demo_full.html`) has also been updated to showcase its usage.