### PR TITLE
style: Improve chart cell height adaptability and vertical alignment

### DIFF
--- a/Dynamic-table/dynamic-table.css
+++ b/Dynamic-table/dynamic-table.css
@@ -173,8 +173,7 @@
     align-items: center;    /* Vertically centers the canvas */
     justify-content: center; /* Horizontally centers the canvas (optional, can be 'flex-start' or 'flex-end') */
     padding: 2px 5px; /* Reduced padding for chart cells to maximize chart space */
-    min-height: 50px; /* Minimum height to help with alignment if uniformChartHeight is small */
-                      /* Adjust this value based on uniformChartHeight */
+    /* min-height: 50px; /* REMOVED to allow more natural row height adjustment */ */
 }
 .dynamic-table tbody td.dt-chart-cell canvas {
     max-width: 100%; /* Ensure the canvas does not exceed the cell */


### PR DESCRIPTION
- Removed `min-height: 50px;` from `.dynamic-table tbody td.dt-chart-cell` CSS.
- This allows chart cells to more naturally adapt their height based on the chart canvas size or the height of other cells in the row.
- The existing `display: flex; align-items: center;` on the chart cell ensures the chart canvas remains vertically centered within the cell, even when row heights change due to text wrapping in other columns.

This change addresses potential layout inconsistencies for chart columns when table width is reduced and row heights become variable.