### PR TITLE
fix: Correct chart cell height, border alignment, and update docs

### DIFF
--- a/Dynamic-table/demo.html
+++ b/Dynamic-table/demo.html
@@ -48,6 +48,10 @@
 
     <script>
     document.addEventListener('DOMContentLoaded', () => {
+        // Example configuration for dynamic-table:
+        // To hide the column visibility selector button (gear icon), add to the config below:
+        // showColumnVisibilitySelector: false, 
+        // (By default, it's true, so the selector will be shown if this line is omitted)
         createDynamicTable({
             containerId: 'main-dynamic-table',
             jsonPath: 'sample-data.json', // Loading from the external JSON file
@@ -63,15 +67,15 @@
             // For this demo, sample_data.json should directly contain the [marketData items] array
             columns: [
                 {
-                    key: 'countryCode',
+                    key: 'countryCode', // Ensure keys are present for columns involved in sorting/filtering/visibility state
                     header: 'Flag',
                     format: 'flag',
                     filterable: true,
                     sortable: true
                 },
                 {
-                    key: 'name', 
-                    header: 'Index', // Translated from 'Indice'
+                    key: 'name', // Ensured key exists
+                    header: 'Index', 
                     sortable: true, 
                     render: (value, rowData, cell) => {
                         const link = document.createElement('a');
@@ -84,7 +88,8 @@
                     }
                 },
                 { 
-                    header: '1 Year Chart', // Translated from 'Graphique 1 an'
+                    key: 'oneYearChart', // Added key
+                    header: '1 Year Chart', 
                     renderAs: 'chart',
                     chartConfig: {
                         type: 'line',
@@ -100,9 +105,10 @@
                     }
                 },
                 { key: 'ytd', header: 'YTD', sortable: true, format: 'percent:2' },
-                { key: 'y1', header: '1 Year', sortable: true, format: 'percent_neutral:2' }, // Translated from '1 An'              
+                { key: 'y1', header: '1 Year', sortable: true, format: 'percent_neutral:2' },              
             ],
             uniformChartHeight: 45,
+            // showColumnVisibilitySelector: true, // Default is true, so selector will be shown
             rowsPerPage: 5,
             rowsPerPageOptions: [3, 5, 10, 20, 'All'], // Translated 'Tout' to 'All'
             showSearchControl: true,

--- a/Dynamic-table/demo_full.html
+++ b/Dynamic-table/demo_full.html
@@ -188,7 +188,7 @@
                 showResultsCount: true,
                 showPagination: true, 
                 showRowsPerPageSelector: true,
-                // showColumnVisibilitySelector: true, // Default, so omitted for this table
+                // showColumnVisibilitySelector: true, // Default behavior, selector will be shown. Explicitly omit to test default.
                 tableMaxHeight: '350px',
                 defaultSortColumn: 'name',
                 defaultSortDirection: 'asc'
@@ -223,7 +223,7 @@
                 showSearchControl: false,
                 showResultsCount: false,
                 showPagination: false,
-                showColumnVisibilitySelector: false, // Demonstrate hiding the selector
+                showColumnVisibilitySelector: false, // Hides the gear icon to toggle column visibility
             });
         } else {
              document.getElementById('table-products-minimal').innerHTML = '<p>"productData" not found.</p>'; // Translated
@@ -247,7 +247,7 @@
                 defaultSortColumn: 'lastName',
                 showPagination: true,
                 showRowsPerPageSelector: false,
-                showColumnVisibilitySelector: true, // Demonstrate explicitly showing (though it's the default)
+                showColumnVisibilitySelector: true, // Explicitly shows the column visibility toggle (default is true)
             });
         } else {
             document.getElementById('table-users-classic').innerHTML = '<p>"userData" not found.</p>'; // Translated

--- a/Dynamic-table/dynamic-table.css
+++ b/Dynamic-table/dynamic-table.css
@@ -169,12 +169,19 @@
 
 /* Style for cells containing charts for vertical alignment */
 .dynamic-table tbody td.dt-chart-cell {
-    display: flex;
-    align-items: center;    /* Vertically centers the canvas */
-    justify-content: center; /* Horizontally centers the canvas (optional, can be 'flex-start' or 'flex-end') */
-    padding: 2px 5px; /* Reduced padding for chart cells to maximize chart space */
-    /* min-height: 50px; /* REMOVED to allow more natural row height adjustment */ */
+    padding: 2px 5px; /* Keep padding */
+    /* display: flex; align-items: center; justify-content: center; -- REMOVED to allow standard cell height behavior */
+    vertical-align: middle; /* Good default for table cell content */
 }
+
+.dt-chart-canvas-wrapper {
+    display: flex;
+    align-items: center;    /* Vertically center the canvas */
+    justify-content: center; /* Horizontally center the canvas */
+    width: 100%;
+    height: 100%; /* Takes full height of the cell, critical for centering in a stretched cell */
+}
+
 .dynamic-table tbody td.dt-chart-cell canvas {
     max-width: 100%; /* Ensure the canvas does not exceed the cell */
     /* max-height is implicitly managed by the canvas height defined in JS */

--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -756,12 +756,19 @@ function createDynamicTable(config) {
                         colConfig.render(value, item, cell);
                     } else if (colConfig.renderAs === 'chart' && colConfig.chartConfig) {
                         cell.classList.add('dt-chart-cell');
+                        
+                        // Create inner wrapper for canvas
+                        const canvasWrapper = document.createElement('div');
+                        canvasWrapper.className = 'dt-chart-canvas-wrapper';
+                        cell.appendChild(canvasWrapper);
+
                         const canvasId = `${containerId}-chart-${startIndex + itemIndex}-${colIndexOriginal}`; // Use original index for unique ID
                         const canvas = document.createElement('canvas');
                         canvas.id = canvasId;
                         canvas.width = colConfig.chartConfig.width || 150;
                         canvas.height = uniformChartHeight || colConfig.chartConfig.height || 75; 
-                        cell.appendChild(canvas);
+                        canvasWrapper.appendChild(canvas); // Append canvas to wrapper
+                        
                         const chartData = item[colConfig.chartConfig.dataKey];
                         if (chartData && typeof PureChart !== 'undefined') {
                             try {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,69 @@
 # web_libs
 All my fast, light, and free Apache 2.0 licensed libraries for web front-ends!
 
-* Dynamic-table: A fast and light HTML table.
-* Extended-search: A fast and light advanced search input field with flags and multi-line information.
-* PureChart: A fast and light chart library.
+## Dynamic-table
+A fast, light, and customizable HTML table generator.
+
+**Features:**
+*   Data loading from JSON path or direct JSON data.
+*   Sortable and filterable columns.
+*   Custom cell rendering, including embedding charts (using PureChart.js).
+*   Pagination, global search, results count, and rows-per-page selector.
+*   Column visibility toggling.
+*   And more...
+
+**Basic Usage:**
+```html
+<div id="myTableContainer"></div>
+<script src="path/to/PureChart.js"></script> <!-- Optional, if using charts -->
+<script src="path/to/dynamic-table.js"></script>
+<script>
+    createDynamicTable({
+        containerId: 'myTableContainer',
+        jsonData: [ /* your data array */ ],
+        columns: [
+            { key: 'id', header: 'ID', sortable: true },
+            { key: 'name', header: 'Name', sortable: true, filterable: true },
+            // ... more columns
+        ]
+    });
+</script>
+```
+
+### Configuration Options
+The `createDynamicTable` function accepts a configuration object with the following parameters:
+
+*   `containerId` (string, required): The ID of the HTML element where the table will be inserted.
+*   `jsonPath` (string): Path to the JSON data file (if `jsonData` is not provided).
+*   `jsonData` (object[]): JSON data array directly (if `jsonPath` is not provided).
+*   `columns` (object[], required): Array describing the columns. Each column object can have:
+    *   `key` (string): The key in the JSON data for this column.
+    *   `header` (string, required): Text to display in the column header.
+    *   `sortable` (boolean, optional, default: `false`): If the column is sortable.
+    *   `filterable` (boolean, optional, default: `false`): If a filter should be created for this column.
+    *   `format` (string, optional): Formatting type (e.g., 'currency:EUR', 'date:YYYY/MM/DD', 'percent:2').
+    *   `render` (function, optional): Custom rendering function for the cell.
+    *   `renderAs` (string, optional, default: `'text'`): Rendering type, e.g., `'chart'`.
+    *   `visible` (boolean, optional, default: `true`): Initial visibility of the column.
+    *   `chartConfig` (object, optional): Configuration if `renderAs` is `'chart'`.
+*   `defaultSortColumn` (string, optional, default: `null`): Key of the column to sort by default.
+*   `defaultSortDirection` (string, optional, default: `'asc'`): Default sort direction ('asc' or 'desc').
+*   `rowsPerPage` (number, optional, default: `10` or first option in `rowsPerPageOptions`): Initial number of rows per page.
+*   `rowsPerPageOptions` (array, optional, default: `[10, 25, 50, 100, 'All']`): Options for the rows per page selector.
+*   `showSearchControl` (boolean, optional, default: `true`): If `true`, shows the global search input field.
+*   `showResultsCount` (boolean, optional, default: `true`): If `true`, shows the results counter.
+*   `showPagination` (boolean, optional, default: `true`): If `true`, shows the pagination controls.
+*   `showRowsPerPageSelector` (boolean, optional, default: `true`): If `true`, shows the rows per page selector (part of pagination).
+*   `showColumnVisibilitySelector` (boolean, optional, default: `true`): If `true`, shows the gear icon button to toggle column visibility. Set to `false` to hide this control.
+*   `tableMaxHeight` (string, optional, default: `null`): Max CSS height for the table scroll wrapper (e.g., '400px').
+*   `uniformChartHeight` (number, optional, default: `null`): If set, forces this height (in px) for all charts in the table.
+
+## Extended-search
+A fast and light advanced search input field with flags and multi-line information.
+*(More documentation to come)*
+
+## PureChart
+A fast and light chart library.
+*(More documentation to come)*
 
 Thank you!


### PR DESCRIPTION
This commit addresses issues related to chart cell rendering when row heights change and updates documentation.

Key Changes:

1.  **Chart Cell Rendering (`dynamic-table.js`, `dynamic-table.css`):**
    -   I modified `renderTableInternal` to insert an inner `div` (class `dt-chart-canvas-wrapper`) within chart cells (`<td>`). The chart canvas is now appended to this inner wrapper.
    -   I removed `display: flex` from the chart cell (`.dt-chart-cell`) to allow it to behave like a standard table cell and stretch to the full row height.
    -   I styled the new `.dt-chart-canvas-wrapper` with `display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;`. This ensures the fixed-height chart canvas is vertically and horizontally centered within the cell, even if the cell becomes taller due to content in other columns.
    -   This resolves issues where chart cell bottom borders would not align with other cells in rows of varying heights, and ensures charts are properly centered vertically.

2.  **Documentation (`README.md`, `demo_full.html`, `demo.html`):**
    -   I updated `README.md` to include the `showColumnVisibilitySelector` configuration option.
    -   I added comments to `demo_full.html` and `demo.html` to explain the usage of `showColumnVisibilitySelector`.
    -   I ensured consistent use of `key` properties for chart columns in demo files.

These changes improve the visual consistency of tables with charts and varying row heights, and ensure documentation is up-to-date.