### PR TITLE
feat: Add average line feature to PureChart

### DIFF
--- a/PureChart/README.md
+++ b/PureChart/README.md
@@ -172,6 +172,73 @@ options: {
 }
 ```
 
+**NEW: Average Line Per Dataset:**
+This feature allows you to draw a horizontal line representing the calculated average of a specific dataset's values. A label displaying the average value can also be shown. This is useful for quickly visualizing how dataset values compare to their mean.
+
+The `averageLine` configuration object can be added directly to any dataset object within the `data.datasets` array, for datasets of `type: 'bar'` or `type: 'line'`. It is not applicable to `percentageDistribution` or `sma` type datasets.
+
+**Configuration Options for `averageLine` (within a dataset object):**
+
+*   `display` (Boolean): Set to `true` to show the average line for this dataset.
+    *   Default: `false`.
+*   `color` (String): Color of the average line.
+    *   Default: `'#888'`.
+*   `lineWidth` (Number): Width of the average line.
+    *   Default: `1`.
+*   `dashPattern` (Array of Numbers): Dash pattern for the line (e.g., `[3, 3]` for dotted, `[]` or `null` for solid).
+    *   Default: `[3, 3]`.
+*   `label` (Object): Configuration for the label displayed near the average line.
+    *   `display` (Boolean): Set to `true` to show the average value label.
+        *   Default: `true`.
+    *   `font` (String): Font for the label.
+        *   Default: `'10px Arial'`.
+    *   `color` (String): Color of the label text.
+        *   Default: `'#555'`.
+    *   `position` (String): Position of the label relative to the line.
+        *   Supported values: `'above-right'`, `'above-left'`, `'below-right'`, `'below-left'`.
+        *   Default: `'above-right'`.
+    *   `padding` (Number): Padding around the label text, especially if `backgroundColor` is used.
+        *   Default: `2`.
+    *   `backgroundColor` (String): Background color for the label, making it more readable over chart elements.
+        *   Default: `'rgba(255, 255, 255, 0.7)'`.
+    *   `formatter` (Function): A function that takes the calculated average value as an argument and returns the string to be displayed.
+        *   Default: `(value) => \`Avg: \${value !== null && value !== undefined ? value.toFixed(2) : 'N/A'}\``.
+
+**Example:**
+
+```javascript
+data: {
+    labels: ['Jan', 'Feb', 'Mar'],
+    datasets: [{
+        label: 'Sales Data',
+        values: [100, 150, 125],
+        type: 'line', // or 'bar'
+        averageLine: {
+            display: true,
+            color: 'blue',
+            lineWidth: 2,
+            dashPattern: [5, 5], // Dashed line
+            label: {
+                display: true,
+                color: 'darkblue',
+                font: 'bold 12px Arial',
+                position: 'above-left', // Display label on the left side, above the line
+                backgroundColor: 'rgba(200, 200, 255, 0.8)',
+                formatter: (avg) => `Average Sale: ${avg.toFixed(1)}`
+            }
+        }
+    }, {
+        label: 'Expenses Data',
+        values: [70, 80, 75],
+        type: 'bar',
+        averageLine: { // Another average line, using more defaults
+            display: true,
+            color: 'red' // Only customize color, other options use defaults
+        }
+    }]
+}
+```
+
 ## Loading Configuration from JSON (`PureChart.fromJSON()`)
 
 You can load chart configurations from an external JSON file. The JSON structure should mirror the JavaScript configuration object.

--- a/PureChart/demo.html
+++ b/PureChart/demo.html
@@ -33,7 +33,21 @@
                             values: [150, 220, 180, 250, 200, 230, 210],
                             backgroundColor: 'rgba(54, 162, 235, 0.6)',
                             borderColor: 'rgba(54, 162, 235, 1)',
-                            borderWidth: 1
+                            borderWidth: 1,
+                            averageLine: {
+                                display: true,
+                                color: 'rgba(0,0,0,0.7)',
+                                lineWidth: 2,
+                                dashPattern: [6, 3],
+                                label: {
+                                    display: true,
+                                    color: 'black',
+                                    font: 'bold 11px Arial',
+                                    position: 'above-left', // Test a different position
+                                    backgroundColor: 'rgba(255,255,255,0.8)',
+                                    formatter: (avg) => `Avg Views: ${avg.toFixed(0)}`
+                                }
+                            }
                         },
                         {
                             label: 'Unique Visitors',

--- a/PureChart/sample-data.json
+++ b/PureChart/sample-data.json
@@ -9,7 +9,20 @@
           "type": "bar",
           "values": [2500, 2700, 2600, 3000, 2800, 2900, 3100],
           "backgroundColor": "rgba(54, 162, 235, 0.7)",
-          "borderColor": "rgba(54, 162, 235, 1)"
+          "borderColor": "rgba(54, 162, 235, 1)",
+          "averageLine": {
+            "display": true,
+            "color": "#FF8C00",
+            "lineWidth": 2,
+            "dashPattern": [4, 4],
+            "label": {
+                "display": true,
+                "font": "10px Arial bold",
+                "color": "#A0522D",
+                "position": "below-right",
+                "backgroundColor": "rgba(255, 255, 255, 0.7)"
+            }
+          }
         },
         {
           "label": "Expenses (Line)",


### PR DESCRIPTION
This commit introduces a new feature to PureChart that allows you to display a horizontal dashed line representing the average of a specific dataset's values. The average value is also displayed as a label near the line.

Key changes:
- Added `averageLine` configuration options to datasets (for bar and line types) in `PureChart.js`. This includes settings for display, color, line style, and label (text, font, color, position, formatter).
- Implemented `_calculateDatasetAverage()` static method to compute the average of dataset values, handling non-numeric entries.
- Implemented `_drawAverageLines()` method to render the average line and its label on the chart canvas, respecting the new configurations.
- Updated `PureChart/README.md` with documentation for the new feature, including configuration options and usage examples.
- Updated `PureChart/demo.html` and `PureChart/sample-data.json` to include examples demonstrating the average line feature.

This feature enhances the analytical capabilities of PureChart by providing a clear visual indicator of dataset averages.