### PR TITLE
feat: Add optional CSRF token to PureChart.fromJSON

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -209,9 +209,15 @@ class PureChart {
         return output;
     }
 
-    static async fromJSON(elementId, jsonUrl, overrideOptions = {}) {
+    static async fromJSON(elementId, jsonUrl, overrideOptions = {}, csrfToken = null) {
         try {
-            const response = await fetch(jsonUrl);
+            const fetchOptions = {};
+            if (csrfToken) {
+                fetchOptions.headers = {
+                    'X-CSRFToken': csrfToken
+                };
+            }
+            const response = await fetch(jsonUrl, fetchOptions);
             if (!response.ok) {
                 console.error(`PureChart Fetch Error: Status ${response.status} for URL ${jsonUrl}`);
                 throw new Error(`PureChart Error: Failed to fetch JSON from ${jsonUrl}. Status: ${response.status}`);

--- a/PureChart/README.md
+++ b/PureChart/README.md
@@ -242,12 +242,24 @@ data: {
 ## Loading Configuration from JSON (`PureChart.fromJSON()`)
 
 You can load chart configurations from an external JSON file. The JSON structure should mirror the JavaScript configuration object.
-**All new features and options described above (dataset `type`, `borderDash`, `sourceDatasetIndex`, `period`, and `options.annotations`) can be included in the JSON configuration.**
+**All new features and options described above (dataset `type`, `borderDash`, `sourceDatasetIndex`, `period`, `options.annotations`, and dataset `averageLine`) can be included in the JSON configuration.**
+
+The `fromJSON` method signature is:
+`PureChart.fromJSON(elementId, jsonUrl, overrideOptions = {}, csrfToken = null)`
+
+*   `elementId` (String): The ID of the canvas element.
+*   `jsonUrl` (String): The URL to fetch the JSON configuration from.
+*   `overrideOptions` (Object, optional): An object that will be deeply merged with the fetched JSON configuration. Defaults to an empty object.
+*   `csrfToken` (String, optional): An optional CSRF token. If provided, its value will be sent as an `X-CSRFToken` header in the HTTP GET request for the `jsonUrl`. This is useful for fetching configurations from server endpoints that require CSRF protection. Defaults to `null`.
 
 ```javascript
-PureChart.fromJSON('myCanvasID', 'path/to/data.json')
+// Example call in README
+PureChart.fromJSON('myCanvasID', 'path/to/data.json', {}, 'YOUR_CSRF_TOKEN_HERE')
     .then(chart => {
-        if (chart && chart.isValid) console.log("Chart loaded from JSON!");
+        if (chart && chart.isValid) console.log("Chart loaded from JSON with CSRF token!");
+    })
+    .catch(error => {
+        console.error("Failed to load chart with CSRF token:", error);
     });
 ```
 Refer to `sample-data.json` in the demo package for a comprehensive example of a JSON configuration file using these new features.

--- a/PureChart/demo_full.html
+++ b/PureChart/demo_full.html
@@ -49,6 +49,12 @@
         <canvas id="percentageChartOldStyleAutonome" width="700" height="200"></canvas>
     </div>
 
+    <div class="chart-container">
+        <h2>Chart 4: Loaded via PureChart.fromJSON()</h2>
+        <p>This chart demonstrates loading data using the <code>PureChart.fromJSON()</code> static method, including the conceptual CSRF token parameter.</p>
+        <canvas id="fromJsonDemoCanvas" width="700" height="350"></canvas>
+    </div>
+
     <script src="PureChart.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', async () => {
@@ -226,9 +232,38 @@
                     document.getElementById('jsonLoadedChartCanvas').outerHTML = "<p>Error: Chart configuration not found in sample-data.json.</p>";
                 }
             } catch (e) {
-                console.error("Error loading chart from JSON for demo_full.html:", e);
-                document.getElementById('jsonLoadedChartCanvas').outerHTML = `<p style="color:red;">Could not load chart from JSON: ${e.message}</p>`;
+                console.error("Error loading chart from JSON for demo_full.html (Chart 3):", e);
+                document.getElementById('jsonLoadedChartCanvas').outerHTML = `<p style="color:red;">Could not load chart from JSON (Chart 3): ${e.message}</p>`;
             }
+
+            // Chart 4: Example of PureChart.fromJSON()
+            PureChart.fromJSON('fromJsonDemoCanvas', 'single_chart_example.json', {}, null /* csrfToken if needed */)
+                .then(chart => {
+                    if (chart && chart.isValid) {
+                        console.log("Chart 'fromJsonDemoCanvas' loaded successfully via PureChart.fromJSON().");
+                    } else {
+                        // This path (chart is null or !chart.isValid) might occur if fromJSON itself handles an error internally
+                        // and returns null or an invalidated chart instance, instead of throwing.
+                        console.error("Failed to load or chart is invalid from 'single_chart_example.json' via PureChart.fromJSON().");
+                        const canvas = document.getElementById('fromJsonDemoCanvas');
+                        if (canvas && canvas.getContext) { // Display error on canvas
+                            const ctx = canvas.getContext('2d');
+                            ctx.clearRect(0, 0, canvas.width, canvas.height);
+                            ctx.font = '12px Arial'; ctx.fillStyle = 'orange'; ctx.textAlign = 'center';
+                            ctx.fillText('Chart loaded but invalid.', canvas.width / 2, canvas.height / 2);
+                        }
+                    }
+                })
+                .catch(error => {
+                    console.error("Error loading chart 'fromJsonDemoCanvas' via PureChart.fromJSON():", error);
+                    const canvas = document.getElementById('fromJsonDemoCanvas');
+                    if (canvas && canvas.getContext) { // Display error on canvas
+                        const ctx = canvas.getContext('2d');
+                        ctx.clearRect(0, 0, canvas.width, canvas.height);
+                        ctx.font = '12px Arial'; ctx.fillStyle = 'red'; ctx.textAlign = 'center';
+                        ctx.fillText(`Error fromJSON: ${String(error.message).substring(0,100)}`, canvas.width / 2, canvas.height / 2);
+                    }
+                });
             
 
             // Config for Bar Chart (Original Demo)

--- a/PureChart/single_chart_example.json
+++ b/PureChart/single_chart_example.json
@@ -1,0 +1,14 @@
+{
+    "type": "bar",
+    "data": {
+        "labels": ["A", "B", "C"],
+        "datasets": [{
+            "label": "Sample Data",
+            "values": [10, 20, 15],
+            "backgroundColor": "rgba(0, 150, 200, 0.6)"
+        }]
+    },
+    "options": {
+        "title": { "text": "Loaded via fromJSON" }
+    }
+}


### PR DESCRIPTION
This commit enhances the `PureChart.fromJSON` static method to support an optional CSRF token.

- I modified `PureChart.fromJSON` in `PureChart.js` to accept a `csrfToken` parameter. If provided, this token is included as an `X-CSRFToken` header in the fetch request.
- I updated `PureChart/README.md` to document the new `csrfToken` parameter in the `PureChart.fromJSON` method signature and its usage.
- I added a new example to `PureChart/demo_full.html` to specifically demonstrate the `PureChart.fromJSON` method, including the new `csrfToken` parameter (passed as null in the static demo).
- I created `PureChart/single_chart_example.json` to serve as a data source for the new `fromJSON` demo in `demo_full.html`.

This change allows developers to use `PureChart.fromJSON` to fetch chart configurations from server endpoints that require CSRF protection.