### PR TITLE
feat: Add X_CSRFToken argument to createDynamicTable

### DIFF
--- a/Dynamic-table/demo.html
+++ b/Dynamic-table/demo.html
@@ -54,6 +54,7 @@
         // (By default, it's true, so the selector will be shown if this line is omitted)
         createDynamicTable({
             containerId: 'main-dynamic-table',
+            X_CSRFToken: 'dummyCSRFTokenForDemo',
             jsonPath: 'sample-data.json', // Loading from the external JSON file
             // Note: dynamic-table.js (v11) expects sample-data.json to be an array.
             // If sample-data.json is an object with keys (like marketData, etc.), 

--- a/Dynamic-table/demo_full.html
+++ b/Dynamic-table/demo_full.html
@@ -128,6 +128,7 @@
         if (sampleData.marketData) {
             createDynamicTable({
                 containerId: 'table-market-demo',
+                X_CSRFToken: 'dummyCSRFTokenForDemo',
                 jsonData: sampleData.marketData, // Using jsonData
                 columns: [
                     {
@@ -202,6 +203,7 @@
         if (sampleData.productData) {
             createDynamicTable({
                 containerId: 'table-products-minimal',
+                X_CSRFToken: 'dummyCSRFTokenForDemo',
                 jsonData: sampleData.productData,
                 columns: [
                     { key: 'productName', header: 'Product', sortable: true }, 
@@ -234,6 +236,7 @@
         if (sampleData.userData) {
             createDynamicTable({
                 containerId: 'table-users-classic',
+                X_CSRFToken: 'dummyCSRFTokenForDemo',
                 jsonData: sampleData.userData,
                 columns: [
                     { key: 'id', header: 'ID', sortable: true },

--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -53,6 +53,7 @@
 function createDynamicTable(config) {
     const {
         containerId,
+        X_CSRFToken,
         jsonPath, 
         jsonData, 
         columns = [],


### PR DESCRIPTION
Adds X_CSRFToken as a property in the config object for the createDynamicTable function.

This allows passing a CSRF token to the function, which can be used in future modifications, for example, if the function needs to make authenticated API requests.

The example calls in demo.html and demo_full.html have been updated to include a placeholder token.