### PR TITLE
Fix: Align column selector dropdown to open inwards

### DIFF
--- a/Dynamic-table/dynamic-table.css
+++ b/Dynamic-table/dynamic-table.css
@@ -523,7 +523,7 @@
 .dt-column-selector-dropdown {
     position: absolute;
     top: 100%; /* Position below the button */
-    left: 0; 
+    right: 0; 
     /* If the button might be close to the right edge, 'right: 0;' might be better,
        or JS positioning. For now, left: 0 is standard. */
     background-color: #fff;


### PR DESCRIPTION
I changed the CSS for `.dt-column-selector-dropdown` from `left: 0;` to `right: 0;`. This makes the column visibility menu open towards the left (inwards into the table area), aligning its right edge with the right edge of the trigger button, as per the requested behavior.