### PR TITLE
Fix: Header filter choices empty after column selector usage

### DIFF
--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -450,6 +450,7 @@ function createDynamicTable(config) {
                 buildHeaderRow(); // Rebuild the header
                 renderTableInternal(); // Re-render table body
                 // updatePaginationControlsInternal(); // Already called by renderTableInternal if pagination is on
+                populateFilterOptions(); // Repopulate all filter options
             });
 
             const label = document.createElement('label');


### PR DESCRIPTION
When you used the column selector to hide and then show a column that had a header filter (select or multiselect type), the filter choices would not be repopulated, appearing empty.

This was because the `populateFilterOptions` function, while correctly capable of populating filters, was not being called after a column's visibility was restored.

The fix involves calling `populateFilterOptions()` within the column visibility checkbox's change event listener in `buildColumnSelector`. This call is made after `buildHeaderRow()` recreates the column header and its filter placeholder, ensuring that the filter is then immediately populated with the correct choices from the original dataset.