### PR TITLE
Fix: Add missing space in Dynamic-Table results count

### DIFF
--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -1353,7 +1353,7 @@ function createDynamicTable(config) {
             // Update the accompanying text node, which is the next sibling of resultsCountSpan
             const textNode = resultsCountSpan.nextSibling;
             if (textNode && textNode.nodeType === Node.TEXT_NODE) {
-                textNode.textContent = ` ${currentLangPack.resultsInfo.replace('{count}', '')}`.trimStart();
+                textNode.textContent = ` ${currentLangPack.resultsInfo.replace('{count}', '')}`;
             }
         }
     }


### PR DESCRIPTION
This commit fixes a formatting issue in `dynamic-table.js` where the results count string was missing a space between the number and the text (e.g., "4résultats" instead of "4 résultats").

The issue was in the `renderTableInternal` function. The line responsible for setting the text part of the results info (e.g., "résultat(s)") was using `.trimStart()` after removing the `{count}` placeholder from the language pack string. If the placeholder was at the beginning of the string (as in "{count} résultat(s)"), `.trimStart()` would remove the leading space created by the replacement.

The fix removes `.trimStart()`, ensuring that the leading space (either from the language pack string itself after replacement, or from an explicit space in the template literal as I've confirmed) is preserved. This results in the correct formatting, for example, "4 résultats".