### PR TITLE
Fix: Repopulate header filters when columns are shown

### DIFF
--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -448,6 +448,7 @@ function createDynamicTable(config) {
                     stateToUpdate.visible = this.checked;
                 }
                 buildHeaderRow(); // Rebuild the header
+                populateFilterOptions(); // Repopulate filter options
                 renderTableInternal(); // Re-render table body
                 // updatePaginationControlsInternal(); // Already called by renderTableInternal if pagination is on
             });


### PR DESCRIPTION
This commit fixes a bug where header filters in the dynamic-table component would appear empty after a column was hidden and then shown again.

The issue was caused by the `populateFilterOptions` function not being called after the `buildHeaderRow` function recreated the header filter elements for newly visible columns.

The fix ensures that `populateFilterOptions` is called immediately after `buildHeaderRow` within the column visibility change event listener. This repopulates the filter options, making them available and functional.