### PR TITLE
fix: Ensure panorama grid fills available vertical and horizontal space

### DIFF
--- a/Panorama/demo.html
+++ b/Panorama/demo.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="../Dynamic-table/dynamic-table.css" />
   <link rel="stylesheet" href="panorama.css" />
   <style>
-    body { font-family: sans-serif; margin: 20px; background-color: #f9f9f9; }
+    body { font-family: sans-serif; /* margin: 20px; background-color: #f9f9f9; -- Removed */ }
     .controls { margin-bottom: 20px; padding: 15px; background-color: #fff; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
     .controls h2 { margin-top: 0; }
     .control-group { margin-bottom: 15px; }
@@ -35,7 +35,7 @@
   </style>
 </head>
 <body>
-
+<div id="app-container">
   <h1>Panorama Dashboard Demo</h1>
 
   <div class="controls">
@@ -207,5 +207,6 @@
 
     });
   </script>
+</div> <!-- Closing app-container -->
 </body>
 </html>

--- a/Panorama/demo_full.html
+++ b/Panorama/demo_full.html
@@ -12,7 +12,7 @@
   
   <style>
     /* Demo page specific styles - these were originally in the <style> tag */
-    body { font-family: sans-serif; margin: 20px; background-color: #f9f9f9; }
+    body { font-family: sans-serif; /* margin: 20px; background-color: #f9f9f9; -- Removed */ }
     .controls { margin-bottom: 20px; padding: 15px; background-color: #fff; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
     .controls h2 { margin-top: 0; }
     .control-group { margin-bottom: 15px; }
@@ -37,7 +37,7 @@
   </style>
 </head>
 <body>
-
+<div id="app-container">
   <h1>Panorama Dashboard Demo</h1>
 
   <div class="controls">
@@ -170,5 +170,6 @@
       // The old initialDashboardData load is removed as autoLoadData takes precedence.
     });
   </script>
+</div> <!-- Closing app-container -->
 </body>
 </html>

--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -1,22 +1,67 @@
-/* General Usability */
-body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #333;
+/* 
+  The following html, body, and #app-container styles are for page layout.
+  In a larger application, these might be in a global stylesheet or specific demo HTML files.
+  For this component's demo, they are included here for convenience.
+*/
+html, body {
+  height: 100%;
+  width: 100%;
   margin: 0;
-  background-color: #f4f7f6; /* Light background for the page */
+  padding: 0;
+  overflow: hidden; /* To prevent viewport scrollbars if nested elements manage their own scroll */
+  box-sizing: border-box;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; /* Moved body font here */
+  background-color: #f4f7f6; /* Moved body background here */
+  color: #333; /* Moved body color here */
 }
 
-#panorama-container {
-  padding: 20px;
+*, *::before, *::after {
+  box-sizing: inherit; /* Ensure all elements use border-box */
+}
+
+#app-container { /* This ID will need to be added to demo HTML, wrapping controls and dashboard-container */
+  display: flex;
+  flex-direction: column; /* Stack controls on top of dashboard area */
+  height: 100%; /* Fill full viewport height */
+  width: 100%; /* Fill full viewport width */
+}
+
+.controls { /* General styling for a controls section associated with Panorama */
+  flex-shrink: 0; /* Prevent controls from shrinking */
+  padding: 15px; 
+  background-color: #fff; 
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  /* overflow-y: auto; /* Consider if controls area itself needs to scroll */
+}
+
+#dashboard-container { /* This ID is from demo HTML files */
+  flex-grow: 1; /* Take remaining vertical space in #app-container */
+  display: flex; 
+  flex-direction: column; 
+  padding: 10px; 
+  background-color: #eef; /* From demo file, or choose a default */
+  border: 1px solid #ccc; /* From demo file, or choose a default */
+  overflow: auto; /* Add scroll if content (grid) overflows */
+}
+
+/* Panorama Component Specific Styles */
+#panorama-container { /* This is the main container passed to the Panorama class constructor in demo.html, but #panorama-grid-container is the actual grid */
+  /* This rule might be redundant if #dashboard-container is used as the main flex child for the dashboard area */
+  /* For now, keeping it as it was, but it might need review based on HTML structure changes */
+  padding: 20px; /* This was the original style, might conflict with new layout */
+  flex-grow: 1; /* If this is meant to be the scrollable dashboard area */
+  display: flex; /* If it's meant to contain the grid and make it grow */
+  flex-direction: column;
 }
 
 /* Grid Container Styling */
 #panorama-grid-container {
-  background-color: #e9ecef; /* Light grey background for the grid area */
-  border: 1px solid #ced4da; /* Subtle border */
-  padding: 10px; /* Padding around the grid */
+  flex-grow: 1; /* Allows the grid to take up available space in #dashboard-container */
+  width: 100%;  /* Ensure it takes full width of #dashboard-container */
+  background-color: #e9ecef; 
+  border: 1px solid #ced4da; 
   border-radius: 4px;
-  min-height: 500px; /* Ensure it's visible and spacious */
+  /* overflow: auto; /* Gridstack manages its own internal scroll/overflow typically */
 }
 
 /* Grid Item Styling */


### PR DESCRIPTION
This commit addresses the issue where the Panorama dashboard grid area was too thin and did not utilize the full available space within its designated container.

Changes include:

1.  **CSS Modifications (`Panorama/panorama.css`):**
    *   Introduced `html, body` base styles for full viewport height/width,
        no margin/padding, and `box-sizing: border-box`.
    *   Defined an `#app-container` style (to be used in demo HTML)
        as a flex container (`display: flex, flex-direction: column, height: 100vh`).
    *   Modified `#dashboard-container` (the direct parent of the grid)
        to be a flex item (`flex-grow: 1`) and a flex container itself
        (`display: flex, flex-direction: column`) to manage the grid's size.
        Added `overflow: auto` to it.
    *   Updated `#panorama-grid-container` to use `flex-grow: 1` to fill
        its parent (`#dashboard-container`) vertically, and `width: 100%`
        to fill horizontally. Removed the fixed `min-height`.
    *   Adjusted `.controls` styling to include `flex-shrink: 0`.

2.  **HTML Updates (`Panorama/demo.html`, `Panorama/demo_full.html`):**
    *   Wrapped the existing body content (controls div and dashboard-container div)
        within a new `<div id="app-container">`.
    *   Adjusted inline `<style>` tags in the demo files to remove
        conflicting `body` margins and backgrounds, ensuring the new
        CSS for full-page layout takes precedence.

These changes allow the panorama grid to dynamically expand to use all available vertical and horizontal space within the dashboard area, which itself now correctly sizes below the controls section relative to the viewport.