### PR TITLE
feat: Replace GridStack.js with custom CSS Grid implementation

### DIFF
--- a/Panorama/demo.html
+++ b/Panorama/demo.html
@@ -3,8 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Panorama Dashboard Demo</title>
-  <!-- GridStack CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@latest/dist/gridstack.min.css" />
   <!-- Component CSS -->
   <link rel="stylesheet" href="../PureChart/PureChart.css" />
   <link rel="stylesheet" href="../Dynamic-table/dynamic-table.css" />
@@ -75,8 +73,6 @@
     <div id="panorama-grid-container" class="grid-stack"></div>
   </div>
 
-  <!-- GridStack JS -->
-  <script src="https://cdn.jsdelivr.net/npm/gridstack@latest/dist/gridstack-all.js"></script>
   <!-- Component JS -->
   <script src="../PureChart/PureChart.js"></script>
   <script src="../Dynamic-table/dynamic-table.js"></script>
@@ -92,7 +88,12 @@
       document.getElementById('add-item-btn').addEventListener('click', () => {
         const itemType = document.getElementById('item-type').value;
         let defaultConfig;
-        const defaultLayout = { x: 0, y: 0, w: 4, h: 2 }; // Default layout for new items
+        // Ensure x and y are at least 1 for CSS Grid 1-based indexing.
+        // A common default is to add to the first available space,
+        // but for simplicity, new items can default to x:1, y:1 or find next available row.
+        // For now, let's use x:1 and a placeholder for y that would need logic to find the next available row.
+        // Or, simply place it at a fixed starting point like x:1, y:1 for every new item.
+        const defaultLayout = { x: 1, y: 1, w: 4, h: 2 }; // Default layout for new items (1-based)
 
         switch (itemType) {
           case 'text':
@@ -186,19 +187,19 @@
             id: 1,
             type: "title",
             config: { text: "Welcome to Panorama!", level: 1 },
-            layout: { x: 0, y: 0, w: 12, h: 1 }
+            layout: { x: 1, y: 1, w: 12, h: 1 } // Adjusted to 1-based
           },
           {
             id: 2,
             type: "text",
             config: { content: "This is a demo of the Panorama dashboard. You can add, remove, edit, and arrange items. Try saving and loading configurations using the controls above." },
-            layout: { x: 0, y: 1, w: 6, h: 2 }
+            layout: { x: 1, y: 2, w: 6, h: 2 } // Adjusted to 1-based
           },
           {
             id: 3,
             type: "image",
             config: { url: 'https://via.placeholder.com/300x150.png?text=Demo+Image', alt: 'Demo Image' },
-            layout: { x: 6, y: 1, w: 6, h: 3 }
+            layout: { x: 7, y: 2, w: 6, h: 3 } // Adjusted to 1-based (x: 6+1=7)
           }
         ],
         itemIdCounter: 3

--- a/Panorama/demo_full.html
+++ b/Panorama/demo_full.html
@@ -3,8 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>Panorama Dashboard Demo</title>
-  <!-- GridStack CSS -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/10.1.2/gridstack.min.css" integrity="sha512-nw3CPHwK9XYh3DRXLSsB9RDZfM98J7gpQZ182lU9W9XK2KWWoR2LhFjYhMvYh3M87g/o2k1iGj15j/x1QyL2Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <!-- Component CSS -->
   <link rel="stylesheet" href="../PureChart/PureChart.css">
   <link rel="stylesheet" href="../Dynamic-table/dynamic-table.css">
@@ -78,7 +76,6 @@
   </div>
 
   <!-- External JS Libraries -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/10.1.2/gridstack.all.js" integrity="sha512-cQpX3xZ2Kx11yJpM/HWbT_X/47zGj4Xh/S/B9rTjM00Lp1s5j0L9G94x/pL9K9A70FmS00kG8h1oQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="../PureChart/PureChart.js"></script>
   <script src="../Dynamic-table/dynamic-table.js"></script>
   <script src="panorama.js"></script> 

--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -10,38 +10,37 @@ html, body {
   padding: 0;
   overflow: hidden; /* To prevent viewport scrollbars if nested elements manage their own scroll */
   box-sizing: border-box;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; /* Moved body font here */
-  background-color: #f4f7f6; /* Moved body background here */
-  color: #333; /* Moved body color here */
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
+  background-color: #f4f7f6; 
+  color: #333; 
 }
 
 *, *::before, *::after {
-  box-sizing: inherit; /* Ensure all elements use border-box */
+  box-sizing: inherit; 
 }
 
-#app-container { /* This ID will need to be added to demo HTML, wrapping controls and dashboard-container */
+#app-container { 
   display: flex;
-  flex-direction: column; /* Stack controls on top of dashboard area */
-  height: 100%; /* Fill full viewport height */
-  width: 100%; /* Fill full viewport width */
+  flex-direction: column; 
+  height: 100%; 
+  width: 100%; 
 }
 
-.controls { /* General styling for a controls section associated with Panorama */
-  flex-shrink: 0; /* Prevent controls from shrinking */
+.controls { 
+  flex-shrink: 0; 
   padding: 15px; 
   background-color: #fff; 
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  /* overflow-y: auto; /* Consider if controls area itself needs to scroll */
 }
 
-#dashboard-container { /* This ID is from demo HTML files */
-  flex-grow: 1; /* Take remaining vertical space in #app-container */
+#dashboard-container { 
+  flex-grow: 1; 
   display: flex; 
   flex-direction: column; 
   padding: 10px; 
-  background-color: #eef; /* From demo file, or choose a default */
-  border: 1px solid #ccc; /* From demo file, or choose a default */
-  overflow: auto; /* Add scroll if content (grid) overflows */
+  background-color: #eef; 
+  border: 1px solid #ccc; 
+  overflow: auto; 
 }
 
 /* Panorama Component Specific Styles */
@@ -59,18 +58,33 @@ html, body {
   background-color: #e9ecef; 
   border: 1px solid #ced4da; 
   border-radius: 4px;
+  /* New CSS Grid styles */
+  display: grid;
+  grid-template-columns: repeat(12, 1fr); /* 12-column grid */
+  grid-auto-rows: minmax(50px, auto); /* Default row height, min 50px, auto-sizing */
+  gap: 10px; /* Space between grid cells */
+  padding: 10px; /* Padding inside the grid container */
 }
 
 /* Grid Item Styling */
-.grid-stack-item {
-  /* GridStack adds its own positioning, focus on content and appearance */
+.panorama-item { 
+  background-color: #ffffff;
+  border: 1px solid #dddddd;
+  border-radius: 4px;
+  overflow: hidden; 
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  display: flex; 
+  flex-direction: column; 
+  position: relative; /* Needed for absolute positioning of resize handle */
 }
 
-.grid-stack-item-content {
-  background-color: #ffffff; 
-  border: 1px solid #dee2e6; 
-  border-radius: 4px; 
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); 
+.panorama-item.dragging-item {
+  opacity: 0.5;
+  border: 2px dashed #007bff; 
+  background-clip: padding-box;
+}
+
+.panorama-item-content { 
   padding: 15px; 
   display: flex;
   flex-direction: column;
@@ -78,29 +92,28 @@ html, body {
   overflow: auto; 
   color: #495057; 
   text-align: left; 
+  flex-grow: 1; 
 }
 
-/* Item Controls Styling (Menu Button and Popup) */
+/* Item Controls Styling (Menu Button and Popup) - Placed inside panorama-item-content */
 .panorama-item-controls {
-  position: relative; /* For positioning popup */
+  position: relative; 
   display: flex;
   justify-content: flex-end; 
-  padding-top: 8px; /* Space above the menu button */
+  padding-top: 8px; 
   background-color: transparent; 
   border-top: none; 
-  /* Removed gap as menu button is now the primary direct child managing its own spacing/look */
 }
 
 .panorama-item-menu-btn {
-  background-color: #f8f9fa; /* Light background */
-  border: 1px solid #ced4da; /* Subtle border */
-  color: #495057; /* Icon color */
-  padding: 4px 8px; /* Adjust padding for icon size */
-  font-size: 1.2em; /* Adjust for icon character '⋮' */
-  line-height: 1; /* Ensure tight fit for icon */
+  background-color: #f8f9fa; 
+  border: 1px solid #ced4da; 
+  color: #495057; 
+  padding: 4px 8px; 
+  font-size: 1.2em; 
+  line-height: 1; 
   border-radius: 4px;
   cursor: pointer;
-  /* margin-left: auto; /* This might not be needed if justify-content: flex-end on parent is enough */
 }
 
 .panorama-item-menu-btn:hover {
@@ -109,43 +122,53 @@ html, body {
 }
 
 .panorama-item-menu-popup {
-  display: none; /* Initially hidden - JS will toggle this */
+  display: none; 
   position: absolute;
-  top: 100%; /* Position below the button */
-  right: 0; /* Align to the right of the controls container */
+  top: 100%; 
+  right: 0; 
   background-color: #ffffff;
   border: 1px solid #dee2e6;
   border-radius: 4px;
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-  z-index: 100; /* Ensure it's above other item content */
+  z-index: 100; 
   min-width: 120px; 
-  padding: 5px 0; /* Padding for items inside */
+  padding: 5px 0; 
 }
 
-.panorama-item-menu-popup a { /* Styles for .panorama-edit-action, .panorama-delete-action */
+.panorama-item-menu-popup a { 
   display: block;
   padding: 8px 12px;
   text-decoration: none;
   color: #343a40;
   font-size: 0.9em;
-  white-space: nowrap; /* Prevent wrapping */
+  white-space: nowrap; 
 }
 
 .panorama-item-menu-popup a:hover {
   background-color: #f8f9fa;
 }
 
-/* Old .panorama-item-controls button styles are removed as they are now superseded by menu styles */
-/* Old .panorama-delete-button specific style is also removed, handled by .panorama-item-menu-popup a */
+/* Resize Handle Styling */
+.panorama-item .resize-handle {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background-color: #ccc;
+    border: 1px solid #333;
+    right: -5px; /* Half out for easier grabbing */
+    bottom: -5px;/* Half out for easier grabbing */
+    cursor: nwse-resize; /* Or se-resize if only bottom-right */
+    z-index: 110; /* Above item content, but potentially below popups if they overlap */
+}
 
 
-/* Specific Item Types Styling */
-.grid-stack-item-content h1,
-.grid-stack-item-content h2,
-.grid-stack-item-content h3,
-.grid-stack-item-content h4,
-.grid-stack-item-content h5,
-.grid-stack-item-content h6 {
+/* Specific Item Types Styling (targeting content within .panorama-item-content) */
+.panorama-item-content h1,
+.panorama-item-content h2,
+.panorama-item-content h3,
+.panorama-item-content h4,
+.panorama-item-content h5,
+.panorama-item-content h6 {
   margin-top: 0;
   margin-bottom: 0.5rem;
   font-weight: 500;
@@ -153,13 +176,13 @@ html, body {
   color: #343a40; 
 }
 
-.grid-stack-item-content p {
+.panorama-item-content p {
   margin-top: 0;
   margin-bottom: 1rem;
   line-height: 1.6;
 }
 
-.grid-stack-item-content img {
+.panorama-item-content img {
   max-width: 100%;
   height: auto;
   border-radius: 3px; 
@@ -282,11 +305,6 @@ html, body {
   border: none;
 }
 
-/* Ensure GridStack resize handles are visible if needed */
-.ui-resizable-handle {
-  z-index: 20; 
-}
-
 /* Helper class for JSON text in modal */
 .panorama-modal-form-area textarea#editJsonConfig {
   font-family: "Courier New", Courier, monospace;
@@ -296,12 +314,12 @@ html, body {
 }
 
 /* Basic styling for placeholder text within items */
-.grid-stack-item-content > p:empty::before {
+.panorama-item-content > p:empty::before { 
     content: "Empty text item";
     color: #adb5bd;
     font-style: italic;
 }
-.grid-stack-item-content > div[id^="chart-container-"]:empty::before {
+.panorama-item-content > div[id^="chart-container-"]:empty::before { 
     content: "Empty chart item";
     color: #adb5bd;
     font-style: italic;
@@ -309,7 +327,7 @@ html, body {
     text-align: center;
     padding-top: 20px; 
 }
-.grid-stack-item-content > div[id^="table-container-"]:empty::before {
+.panorama-item-content > div[id^="table-container-"]:empty::before { 
     content: "Empty table item";
     color: #adb5bd;
     font-style: italic;


### PR DESCRIPTION
This major refactor removes the GridStack.js dependency and implements core dashboard functionalities (grid layout, item dragging, item resizing) using a custom solution based on native CSS Grid and JavaScript event handling.

Key Changes:

1.  **GridStack Removal:**
    *   Removed GridStack CSS and JS dependencies from demo HTML files.
    *   Eliminated GridStack initialization and all API usage (`init`, `makeWidget`, `removeAll`, event listeners) from `Panorama/panorama.js`.
    *   Removed GridStack-specific CSS overrides from `Panorama/panorama.css`.

2.  **Custom CSS Grid Layout (`Panorama/panorama.css`):**
    *   `#panorama-grid-container` is now a CSS Grid container (`display: grid`), typically with 12 columns and auto-sizing rows (min-height 50px).
    *   `.panorama-item` class introduced for dashboard items, styled for the CSS Grid.

3.  **Rendering Logic (`Panorama/panorama.js`):**
    *   `_renderItem` now applies CSS Grid positioning styles (`gridColumnStart`, `gridRowStart`, `gridColumnEnd`, `gridRowEnd`) directly to item elements based on their `layout` properties (x, y, w, h in grid units).
    *   `renderDashboard` clears the grid container and re-appends all items based on the new rendering logic.

4.  **Item Dragging (`Panorama/panorama.js`):**
    *   Implemented using native HTML Drag and Drop API.
    *   Items set `draggable="true"`.
    *   `dragstart` on items transfers `itemId`.
    *   `dragover` on the grid container allows dropping.
    *   `drop` on the grid container calculates the new grid cell based on drop coordinates (relative to grid, considering padding, gaps, and cell dimensions from computed styles) and updates the item's layout.

5.  **Item Resizing (`Panorama/panorama.js`, `Panorama/panorama.css`):**
    *   Added resize handles (bottom-right) to items.
    *   `mousedown` on a handle initiates resize, capturing initial mouse position and item pixel dimensions.
    *   `mousemove` on the document updates the item's `gridColumnEnd`/`gridRowEnd` styles live, converting pixel changes to grid spans using a refined formula: `span = Math.round((pixelDimension + gridGap) / (trackSize + gridGap))`. Track dimensions are derived from computed styles.
    *   `mouseup` on the document finalizes the resize, updates the item's `layout.w` and `layout.h` in the data model, and ensures visual style consistency.

6.  **Layout & Data:**
    *   `saveDashboard` and `loadDashboard` functionality remains compatible, as the `item.layout` object structure is preserved.
    *   Snap-to-grid logic for drag and resize is based on calculated cell dimensions, with vertical snapping to a virtual grid defined by minimum row heights.

This custom implementation provides core dashboard grid functionalities without external dependencies, offering more control over behavior and styling.