### PR TITLE
Fix: Adjust drop placeholder proximity and menu button position

### DIFF
--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -122,9 +122,9 @@ html, body {
 .panorama-item-controls {
   position: relative; 
   display: flex;
-  justify-content: flex-start; /* Changed from flex-end */
+  justify-content: flex-end; /* Changed to flex-end to align button to the right */
   align-items: flex-start; /* Ensure alignment to the top */
-  padding: 5px; /* Uniform padding, removed specific padding-top */
+  padding: 5px; /* Uniform padding for spacing from top and right */
   background-color: transparent; 
   border-top: none; 
 }

--- a/Panorama/panorama.js
+++ b/Panorama/panorama.js
@@ -42,11 +42,34 @@ class Panorama {
       const cellWidth = (this.gridContainer.clientWidth - (2 * gridPaddingLeft) - ((numColumns - 1) * gridGap)) / numColumns;
       const cellHeightApproximation = 50 + gridGap;
 
-      let potentialGridX = Math.floor((dropX - gridPaddingLeft + gridGap / 2) / (cellWidth + gridGap)) + 1;
-      let potentialGridY = Math.floor((dropY - gridPaddingTop + gridGap / 2) / (cellHeightApproximation)) + 1;
+      let mouseGridX = Math.floor((dropX - gridPaddingLeft + gridGap / 2) / (cellWidth + gridGap)) + 1;
+      let mouseGridY = Math.floor((dropY - gridPaddingTop + gridGap / 2) / (cellHeightApproximation)) + 1;
       
-      potentialGridX = Math.max(1, Math.min(potentialGridX, numColumns - this.draggedItem.layout.w + 1));
-      potentialGridY = Math.max(1, potentialGridY);
+      // --- Define Maximum Offset ---
+      const maxPlaceholderOffset = 3; // Max 3 grid cells away
+
+      // --- Get Dragged Item's Current Position ---
+      const draggedItemCurrentX = this.draggedItem.layout.x;
+      const draggedItemCurrentY = this.draggedItem.layout.y;
+
+      // --- Calculate Target Placeholder Position (Initial) ---
+      let targetX = mouseGridX;
+      let targetY = mouseGridY;
+
+      // --- Constrain Placeholder Position ---
+      const diffX = targetX - draggedItemCurrentX;
+      const diffY = targetY - draggedItemCurrentY;
+
+      if (Math.abs(diffX) > maxPlaceholderOffset) {
+        targetX = draggedItemCurrentX + (maxPlaceholderOffset * Math.sign(diffX));
+      }
+      if (Math.abs(diffY) > maxPlaceholderOffset) {
+        targetY = draggedItemCurrentY + (maxPlaceholderOffset * Math.sign(diffY));
+      }
+
+      // --- Apply Constraints and Boundaries (similar to existing logic) ---
+      targetX = Math.max(1, Math.min(targetX, numColumns - this.draggedItem.layout.w + 1));
+      targetY = Math.max(1, targetY); // Y can grow, but not less than 1
 
       // Create or update placeholder
       if (!this.dropPlaceholder) {
@@ -55,15 +78,15 @@ class Panorama {
         this.gridContainer.appendChild(this.dropPlaceholder);
       }
 
-      this.dropPlaceholder.style.gridColumnStart = potentialGridX;
-      this.dropPlaceholder.style.gridRowStart = potentialGridY;
+      this.dropPlaceholder.style.gridColumnStart = targetX;
+      this.dropPlaceholder.style.gridRowStart = targetY;
       this.dropPlaceholder.style.gridColumnEnd = `span ${this.draggedItem.layout.w}`;
       this.dropPlaceholder.style.gridRowEnd = `span ${this.draggedItem.layout.h}`;
 
-      // --- Collision Detection for Placeholder ---
+      // --- Collision Detection for Placeholder (using constrained targetX, targetY) ---
       const potentialLayout = { 
-        x: potentialGridX, 
-        y: potentialGridY, 
+        x: targetX, 
+        y: targetY, 
         w: this.draggedItem.layout.w, 
         h: this.draggedItem.layout.h 
       };


### PR DESCRIPTION
This commit addresses specific feedback you provided on UI elements in the Panorama component:

1.  **Drop Placeholder Proximity:**
    *   The logic for placing the drop placeholder during item dragging has been refined.
    *   The placeholder now stays constrained within a maximum offset (e.g., 3 grid cells) from the actual item being dragged, rather than jumping to a distant mouse cursor. This provides a more intuitive visual cue for where the item might land if dropped nearby.
    *   Collision detection for the placeholder remains active with this new constrained positioning.

2.  **Menu Button Relocated to Top-Right:**
    *   The item menu button (⋮) has been moved from the top-left to the top-right corner of each panorama item.
    *   CSS for `.panorama-item-controls` was updated to `justify-content: flex-end;` while maintaining `align-items: flex-start;` and uniform padding for consistent spacing from the top and right edges.
    *   The menu popup positioning has been verified to work with the button in its new location.

These changes further refine the user experience based on your direct feedback.