### PR TITLE
fix: Resolve item rendering issues with CSS adjustments

### DIFF
--- a/Panorama/PanoramaGrid.css
+++ b/Panorama/PanoramaGrid.css
@@ -26,7 +26,14 @@
 
 .panorama-grid-custom-item-content {
     padding: 10px;
-    /* Add more styles for the content area of an item */
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start; /* Changed from center to allow natural top-to-bottom flow */
+    align-items: stretch;       /* Changed from center to allow content to take full width */
+    flex-grow: 1;
+    overflow: auto; /* Allow scrolling for content that exceeds the item's bounds */
+    height: 100%; /* Ensure it utilizes the height of .panorama-grid-custom-item */
+    box-sizing: border-box; /* Padding should not add to the 100% height */
 }
 
 .panorama-grid-custom-item.pg-dragging {

--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -58,12 +58,12 @@ html, body {
   background-color: #e9ecef; 
   border: 1px solid #ced4da; 
   border-radius: 4px;
-  /* New CSS Grid styles */
-  display: grid;
-  grid-template-columns: repeat(12, 1fr); /* 12-column grid */
-  grid-auto-rows: minmax(50px, auto); /* Default row height, min 50px, auto-sizing */
-  gap: 15px; /* Space between grid cells */
-  padding: 10px; /* Padding inside the grid container */
+  /* New CSS Grid styles -- These are now controlled by PanoramaGrid.js and PanoramaGrid.css */
+  /* display: grid; */
+  /* grid-template-columns: repeat(12, 1fr); */ /* 12-column grid */
+  /* grid-auto-rows: minmax(50px, auto); */ /* Default row height, min 50px, auto-sizing */
+  /* gap: 15px; */ /* Space between grid cells */
+  /* padding: 10px; */ /* Padding inside the grid container */
 }
 
 /* Grid Item Styling */


### PR DESCRIPTION
This commit addresses a critical bug where grid items and their content were not displaying after the integration of the PanoramaGrid library.

The primary fixes include:
1.  **Resolving CSS Conflicts:** I commented out conflicting `display: grid` and related properties from `#panorama-grid-container` in `panorama.css`. These properties are now exclusively controlled by `PanoramaGrid.css` via the `.panorama-grid-custom-container` class and JavaScript-driven CSS variables, ensuring a single source of truth for the main grid structure.
2.  **Enhancing Content Container Styling:** I significantly improved the CSS for `.panorama-grid-custom-item-content` in `PanoramaGrid.css`. I added `display: flex`, `flex-direction: column`, `flex-grow: 1`, `align-items: stretch`, `justify-content: flex-start`, `height: 100%`, `box-sizing: border-box`, and `overflow: auto`. These changes ensure that the content area within each grid item behaves robustly, correctly fills the item's bounds, and allows content to scroll if it overflows.

These changes are expected to restore the visibility of grid blocks and their content.