### PR TITLE
feat: Implement drag placeholder for PanoramaGrid

### DIFF
--- a/Panorama/PanoramaGrid.css
+++ b/Panorama/PanoramaGrid.css
@@ -91,3 +91,13 @@
     outline: 2px dashed #007bff;
     opacity: 0.9; /* Slightly different from dragging if desired */
 }
+
+.pg-drag-placeholder {
+    background-color: rgba(0, 123, 255, 0.1); /* Semi-transparent blue */
+    border: 2px dashed #007bff;
+    border-radius: 4px;
+    box-sizing: border-box;
+    z-index: 1; /* Below dragged item (which is ~1000), above other items */
+    pointer-events: none; /* Should not interfere with mouse events */
+    /* Ensure it doesn't have padding that affects its perceived size vs item */
+}

--- a/Panorama/PanoramaGrid.js
+++ b/Panorama/PanoramaGrid.js
@@ -39,6 +39,7 @@ class PanoramaGrid {
         this._boundHandleResizeEnd = null;   // For storing bound mouseup handler
 
         this._events = {};
+        this.dragPlaceholderElement = null;
 
         this._init();
     }
@@ -285,6 +286,17 @@ class PanoramaGrid {
         // Initialize potentialLayout on the item being dragged
         this.draggedItem.potentialLayout = { ...itemObject.layout };
 
+        if (!this.dragPlaceholderElement) {
+            this.dragPlaceholderElement = document.createElement('div');
+            this.dragPlaceholderElement.className = 'pg-drag-placeholder';
+        }
+        this.dragPlaceholderElement.style.gridColumnStart = '';
+        this.dragPlaceholderElement.style.gridRowStart = '';
+        this.dragPlaceholderElement.style.gridColumnEnd = '';
+        this.dragPlaceholderElement.style.gridRowEnd = '';
+        this.dragPlaceholderElement.style.width = '';
+        this.dragPlaceholderElement.style.height = '';
+
 
         if (itemObject.element) {
             itemObject.element.classList.add('pg-dragging');
@@ -347,6 +359,21 @@ class PanoramaGrid {
             h: this.draggedItemInitialLayout.h
         };
 
+        if (this.dragPlaceholderElement) {
+            const phLayout = this.draggedItem.potentialLayout;
+            this.dragPlaceholderElement.style.gridColumnStart = phLayout.x;
+            this.dragPlaceholderElement.style.gridRowStart = phLayout.y;
+            this.dragPlaceholderElement.style.gridColumnEnd = `span ${phLayout.w}`;
+            this.dragPlaceholderElement.style.gridRowEnd = `span ${phLayout.h}`;
+
+            const phHeight = (phLayout.h * this.options.rowHeight) + ((phLayout.h - 1) * this.options.gap);
+            this.dragPlaceholderElement.style.height = `${phHeight}px`;
+
+            if (!this.dragPlaceholderElement.parentNode) {
+                this.containerElement.appendChild(this.dragPlaceholderElement);
+            }
+        }
+
         // console.log(`PanoramaGrid: Drag Move - dx:${dx}, dy:${dy}, gridDeltaX:${gridDeltaX}, gridDeltaY:${gridDeltaY}, Potential:`, this.draggedItem.potentialLayout);
     }
 
@@ -376,6 +403,10 @@ class PanoramaGrid {
             this._boundHandleDragMove = null;
             this._boundHandleDragEnd = null;
             return;
+        }
+
+        if (this.dragPlaceholderElement && this.dragPlaceholderElement.parentNode) {
+            this.dragPlaceholderElement.parentNode.removeChild(this.dragPlaceholderElement);
         }
 
         // Clear the visual transform effect immediately


### PR DESCRIPTION
This commit introduces a visual placeholder during drag operations in the PanoramaGrid.

- A `div` element with the class `.pg-drag-placeholder` is now created.
- During `_handleDragMove`, this placeholder is styled and positioned on the grid according to the dragged item's potential layout (x, y, w, h), including its calculated height.
- The placeholder is added to the DOM when a drag move occurs and removed when the drag operation ends (`_handleDragEnd`).
- CSS styles have been added to `PanoramaGrid.css` for the placeholder, making it semi-transparent with a dashed border, ensuring it's visually distinct and does not interfere with mouse events.

This feature enhances your experience by providing clear feedback on the potential drop location and size of an item being dragged.