### PR TITLE
Fix: Correct configuration for Fixed Size Chart in PureChart demo

### DIFF
--- a/PureChart/demo_full.html
+++ b/PureChart/demo_full.html
@@ -756,6 +756,8 @@
             if (fixedSizeCtx_full) {
                 new PureChart(fixedSizeCtx_full.id, {
                     type: 'bar', // Changed from pie for safety
+                    width: 450,
+                    height: 280,
                     data: {
                         labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple'],
                         datasets: [{
@@ -766,8 +768,6 @@
                     },
                     options: {
                         autosize: false,
-                        width: 450,
-                        height: 280,
                         title: { text: 'Fixed Size Chart (450x280)' }
                     }
                 });


### PR DESCRIPTION
The 'Fixed Size Chart Demo (Autosize Off)' in `PureChart/demo_full.html` was not displaying correctly and showed a 'Drawing area too small' error.

This was due to the `width` and `height` properties for this chart being incorrectly placed within the nested `options` object in its JavaScript configuration.

This commit moves the `width: 450` and `height: 280` properties to be top-level properties of the chart's configuration object, parallel to `type`, `data`, and `options`. This ensures that the PureChart library correctly interprets these dimensions for a non-autosizing chart, allowing it to render at the intended fixed size.