### PR TITLE
Feat: Add direct percentage mode to percentageDistribution charts

### DIFF
--- a/PureChart/README.md
+++ b/PureChart/README.md
@@ -140,6 +140,33 @@ Customizes chart appearance and behavior.
 **Type-Specific Options (`options.bar`, `options.line`, `options.percentageDistribution`):**
 * (Refer to existing documentation for these.)
 
+#### `percentageDistribution` Specific Options
+
+Under `options.percentageDistribution`:
+
+*   **`valuesArePercentages`** (boolean, default: `false`):
+    *   If set to `true`, the chart will interpret the `value` property of each object in `data.items` as a direct percentage (expected to be in the 0-100 range). The chart will not sum values to calculate percentages. Values outside the 0-100 range will be clamped for display purposes, and a console warning will be issued during chart initialization.
+    *   If `false` (the default), the chart calculates percentages by summing all `item.value`s and determining each item's share of that total.
+
+    Example:
+    ```javascript
+    new PureChart('myChart', {
+        type: 'percentageDistribution',
+        data: {
+            items: [
+                { label: 'Category A', value: 60 }, // Interpreted as 60%
+                { label: 'Category B', value: 40 }  // Interpreted as 40%
+            ]
+        },
+        options: {
+            percentageDistribution: {
+                valuesArePercentages: true
+                // ... other options like barHeight, colors, labelPosition, etc.
+            }
+        }
+    });
+    ```
+
 **NEW: `options.theme` (String):**
 *   Specifies the color theme for the chart.
 *   Possible values:

--- a/PureChart/demo_full.html
+++ b/PureChart/demo_full.html
@@ -98,6 +98,14 @@
 
     <hr style="margin-top: 40px; margin-bottom: 40px;">
 
+    <div class="chart-container">
+        <h2>Percentage Chart (Direct Values)</h2>
+        <p>Demonstrates <code>percentageDistribution</code> type with <code>valuesArePercentages: true</code>. Input values are used directly as percentages.</p>
+        <canvas id="directPercentageChartCanvas" width="700" height="250"></canvas>
+    </div>
+
+    <hr style="margin-top: 40px; margin-bottom: 40px;">
+
     <h2>Chart Destroy Demo</h2>
     <div id="destroyableContainer_full" style="width: 500px; height: 300px; border: 1px solid #ccc; padding: 10px; margin-bottom: 10px;">
         <canvas id="destroyableChartCanvas_full"></canvas>
@@ -852,6 +860,34 @@
                 });
             }
             // --- Appended Demos End ---
+
+            // Percentage Chart (Direct Values) Demo
+            const directPercentageChartConfig = {
+                type: "percentageDistribution",
+                data: {
+                    items: [
+                        { "label": "Task A Progress", "value": 80 },
+                        { "label": "Task B Progress", "value": 55.7 },
+                        { "label": "Task C Blocked", "value": 10.3 },
+                        { "label": "Task D Critical", "value": 150 }, // Example of value > 100
+                        { "label": "Task E Negative", "value": -10 }  // Example of value < 0
+                    ]
+                },
+                options: {
+                    title: { text: "Project Status (Direct Percentages)" },
+                    percentageDistribution: {
+                        valuesArePercentages: true, // Key option for this demo
+                        colors: ["#4CAF50", "#FFC107", "#F44336", "#795548", "#00BCD4"], // Example colors
+                        barHeight: 25,
+                        barBorderRadius: 5,
+                        labelPosition: 'left',
+                        maxLabelWidth: 180,
+                        valuePosition: 'insideEnd',
+                        valueFont: "12px Arial Black"
+                    }
+                }
+            };
+            new PureChart('directPercentageChartCanvas', directPercentageChartConfig);
         });
     </script>
 </body>


### PR DESCRIPTION
This commit introduces a new feature to PureChart's `percentageDistribution` type.

A new boolean option, `valuesArePercentages`, has been added to `options.percentageDistribution` (defaulting to `false`).

- When `valuesArePercentages` is `true`, the chart interprets the `value` property of each item in `data.items` as a pre-calculated percentage (0-100). The chart will use these values directly, clamping them to the 0-100 range for drawing and issuing a console warning for out-of-range values during validation.
- When `false` (default), the chart maintains its original behavior of summing all item values and calculating each item's percentage of that total.

This enhancement provides flexibility for you if you already have percentage data and wish to display it directly without further calculation by the chart.

Changes include:
- Addition of the `valuesArePercentages` option in `PureChart.js` defaults.
- Modification of `_drawPercentageBarChart` to handle the new mode.
- Optional validation in `_validateConfig` to warn about out-of-range direct percentage values.
- A new demo in `PureChart/demo_full.html` showcasing the feature.
- Updated documentation in `PureChart/README.md`.