### PR TITLE
Fix: Ensure Panorama block menus are always visible

### DIFF
--- a/Panorama/PanoramaGrid.css
+++ b/Panorama/PanoramaGrid.css
@@ -16,7 +16,7 @@
     border: 1px solid #cccccc;
     border-radius: 4px;
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
-    overflow: hidden; /* Or 'auto' if content might scroll */
+    overflow: visible; /* Ensures popups are not clipped */
     position: relative; /* For potential absolute positioned children or pseudo-elements */
 
     /* Grid positioning will be set by JS via style attributes:

--- a/Panorama/panorama.js
+++ b/Panorama/panorama.js
@@ -60,13 +60,14 @@ class Panorama {
     }
 
     // --- Add Item Controls ---
-    if (itemElement) { // Only add controls if we have the main item element
+    // Ensure contentContainerElement itself is valid before proceeding
+    if (contentContainerElement) {
         try {
-            let controlsContainer = itemElement.querySelector('.panorama-item-controls');
+            let controlsContainer = contentContainerElement.querySelector('.panorama-item-controls'); // Query from contentContainerElement
             if (!controlsContainer) {
                 controlsContainer = document.createElement('div');
                 controlsContainer.className = 'panorama-item-controls';
-                itemElement.appendChild(controlsContainer); // Changed from insertBefore
+                contentContainerElement.insertBefore(controlsContainer, contentContainerElement.firstChild); // Prepend to contentContainerElement
             } else {
                 controlsContainer.innerHTML = ''; // Clear old buttons if re-rendering
             }
@@ -141,6 +142,8 @@ class Panorama {
         } catch (e) {
             console.error("Error creating controls for item", itemId, e);
         }
+    } else {
+        console.warn('Panorama Debug: contentContainerElement is null or undefined. Cannot add controls for itemId:', itemId);
     }
     // --- End Item Controls ---
 


### PR DESCRIPTION
This commit addresses an issue where the menu for each block (item) in the Panorama demo was not displaying correctly.

Changes:
1. Modified `Panorama/panorama.js` in `_renderPanoramaItemContent`:
   - The item controls (containing the menu button and popup) are now created within and prepended to the `contentContainerElement` of each item. This ensures the menu button is part of the item's primary content area and correctly flows with the layout.

2. Modified `Panorama/PanoramaGrid.css`:
   - Changed the `overflow` property of the `.panorama-grid-custom-item` class from `hidden` to `visible`. This prevents the absolutely positioned popup menu from being clipped if it extends beyond the item's boundaries.

These changes ensure that the menu button is visible within each block and that its popup menu displays correctly without being clipped.