### PR TITLE
Feat: Add Period Highlighting to Line Charts

### DIFF
--- a/PureChart/README.md
+++ b/PureChart/README.md
@@ -276,6 +276,87 @@ data: {
 }
 ```
 
+### Period Highlighting (for Line Charts)
+
+Line charts can display highlighted periods on the X-axis, useful for indicating events, crises, or other significant time ranges. This is configured via the `options.periodHighlights` object.
+This feature is primarily designed for charts with a continuous X-axis where labels represent dates (e.g., 'YYYY-MM-DD').
+
+**`options.periodHighlights` Object Properties:**
+
+*   **`display`**: `boolean` (Default: `false`)
+    *   Set to `true` to enable period highlighting and show the corresponding legend item (if `legendLabel` is also provided).
+*   **`legendLabel`**: `string` (Default: `"Periods"`)
+    *   The text label for the legend item that globally toggles the visibility of all period highlights.
+*   **`periods`**: `Array<Object>` (Default: `[]`)
+    *   An array of period definition objects. Each object defines a single highlighted region.
+*   **`defaultStyle`**: `Object`
+    *   Defines the default appearance for all period highlights and their labels.
+    *   **`fillColor`**: `string` (e.g., `'rgba(255, 0, 0, 0.1)'`) - Fill color of the rectangle.
+    *   **`borderColor`**: `string` (e.g., `'rgba(255, 0, 0, 0.3)'`) - Border color of the rectangle.
+    *   **`borderWidth`**: `number` (e.g., `1`) - Border width of the rectangle.
+    *   **`label`**: `Object` - Default styling for the period name labels.
+        *   **`font`**: `string` (e.g., `'10px Arial'`)
+        *   **`color`**: `string` (e.g., `'#000000'`)
+        *   **`angle`**: `number` (e.g., `-30`) - Rotation angle in degrees.
+        *   **`position`**: `string` (e.g., `'above'`, `'center'`, `'below'`) - Label's position relative to the rectangle.
+        *   **`offset`**: `number` (e.g., `5`) - Pixel offset from the rectangle's edge or center.
+        *   **`textAlign`**: `string` (e.g., `'center'`)
+
+**Period Object Properties (within the `periods` array):**
+
+*   **`name`**: `string` (Required)
+    *   The name of the period, displayed as a label.
+*   **`startDate`**: `string` (Required, format: 'YYYY-MM-DD')
+    *   The start date of the period. The highlight will snap to the nearest date found in `data.labels`.
+*   **`endDate`**: `string` (Required, format: 'YYYY-MM-DD')
+    *   The end date of the period. The highlight will snap to the nearest date found in `data.labels`.
+*   **`style`**: `Object` (Optional)
+    *   Allows overriding any of the `defaultStyle` properties (including nested `defaultStyle.label` properties) for this specific period.
+
+**Example Configuration:**
+
+```javascript
+options: {
+    // ... other chart options for a line chart with date labels ...
+    periodHighlights: {
+        display: true,
+        legendLabel: "Key Economic Events",
+        periods: [
+            {
+                name: "Tech Boom",
+                startDate: "2023-03-01", // Example: assumes "2023-03-01" is in your data.labels
+                endDate: "2023-04-15"   // Example: assumes "2023-04-15" is in your data.labels
+                // Uses defaultStyle defined globally in PureChart.js or overridden in this chart's periodHighlights.defaultStyle
+            },
+            {
+                name: "Market Correction",
+                startDate: "2023-05-01",
+                endDate: "2023-06-15",
+                style: {
+                    fillColor: 'rgba(255, 165, 0, 0.15)', // Light orange
+                    borderColor: 'rgba(255, 165, 0, 0.4)',
+                    label: {
+                        color: '#B22222', // Firebrick
+                        angle: 0,         // Horizontal label
+                        position: 'center',
+                        font: 'bold 10px sans-serif'
+                    }
+                }
+            }
+        ],
+        defaultStyle: { // Example of overriding global defaults for this specific chart instance
+            fillColor: 'rgba(128, 0, 128, 0.08)', // Light purple default
+            borderColor: 'rgba(128, 0, 128, 0.25)',
+            label: {
+                color: '#555555',
+                angle: -20,
+                position: 'above'
+            }
+        }
+    }
+}
+```
+
 ## Loading Configuration from JSON (`PureChart.fromJSON()`)
 
 You can load chart configurations from an external JSON file. The JSON structure should mirror the JavaScript configuration object.

--- a/PureChart/demo_full.html
+++ b/PureChart/demo_full.html
@@ -106,6 +106,14 @@
 
     <hr style="margin-top: 40px; margin-bottom: 40px;">
 
+    <div class="chart-container">
+        <h2>Line Chart with Period Highlighting</h2>
+        <p>Demonstrates a line chart with date-based X-axis and highlighted historical periods using the <code>periodHighlights</code> option.</p>
+        <canvas id="periodHighlightChartCanvas" width="700" height="400"></canvas>
+    </div>
+
+    <hr style="margin-top: 40px; margin-bottom: 40px;">
+
     <h2>Chart Destroy Demo</h2>
     <div id="destroyableContainer_full" style="width: 500px; height: 300px; border: 1px solid #ccc; padding: 10px; margin-bottom: 10px;">
         <canvas id="destroyableChartCanvas_full"></canvas>
@@ -888,6 +896,76 @@
                 }
             };
             new PureChart('directPercentageChartCanvas', directPercentageChartConfig);
+
+            // Line Chart with Period Highlighting Demo
+            const periodHighlightChartConfig = {
+                type: 'line',
+                data: {
+                    labels: [
+                        "2023-01-01", "2023-01-15", "2023-02-01", "2023-02-15", 
+                        "2023-03-01", "2023-03-15", "2023-04-01", "2023-04-15",
+                        "2023-05-01", "2023-05-15", "2023-06-01", "2023-06-15",
+                        "2023-07-01", "2023-07-15", "2023-08-01"
+                    ],
+                    datasets: [{
+                        label: "Stock XYZ",
+                        values: [100, 102, 105, 103, 107, 110, 115, 112, 108, 105, 100, 98, 101, 103, 105],
+                        borderColor: 'rgba(0,123,255,1)', // Bootstrap Primary Blue
+                        backgroundColor: 'rgba(0,123,255,0.1)',
+                        tension: 0.1,
+                        fill: true
+                    }]
+                },
+                options: {
+                    title: { text: "Stock Prices with Highlighted Economic Periods" },
+                    xAxis: { title: 'Date' },
+                    yAxis: { title: 'Price', beginAtZero: false },
+                    periodHighlights: {
+                        display: true, 
+                        legendLabel: "Economic Events",
+                        periods: [
+                            {
+                                name: "Q1 Rally",
+                                startDate: "2023-01-15",
+                                endDate: "2023-03-30"
+                                // Uses defaultStyle from PureChart.js
+                            },
+                            {
+                                name: "Correction",
+                                startDate: "2023-04-01",
+                                endDate: "2023-05-31",
+                                style: {
+                                    fillColor: 'rgba(255, 193, 7, 0.15)', // Light warning yellow
+                                    borderColor: 'rgba(255, 193, 7, 0.4)',
+                                    label: {
+                                        color: '#721c24', // Dark red for contrast
+                                        angle: 0, 
+                                        position: 'center',
+                                        font: 'bold 10px Arial'
+                                    }
+                                }
+                            },
+                            {
+                                name: "Recovery Speculation",
+                                startDate: "2023-06-10",
+                                endDate: "2023-07-10",
+                                style: {
+                                    fillColor: 'rgba(40, 167, 69, 0.1)', // Light success green
+                                    borderColor: 'rgba(40, 167, 69, 0.3)',
+                                    label: {
+                                        color: '#155724', // Dark green
+                                        angle: -25,
+                                        position: 'above',
+                                        offset: 8,
+                                        font: 'italic 9px Verdana'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+            new PureChart('periodHighlightChartCanvas', periodHighlightChartConfig);
         });
     </script>
 </body>


### PR DESCRIPTION
This commit introduces a new 'Period Highlighting' feature for line charts in PureChart.

You can now define specific time periods to be visually highlighted on charts that use a date-based x-axis (labels in 'YYYY-MM-DD' format).

Key aspects of the feature:
- Configuration: A new `options.periodHighlights` object allows you to define an array of `periods` (each with `name`, `startDate`, `endDate`, and optional custom `style`).
- Appearance: Highlights are drawn as semi-transparent rectangles. Period names are displayed as labels, which can be rotated and positioned. Both rectangle and label styles are configurable via `defaultStyle` and per-period overrides.
- Interactivity: A global legend item (label configurable via `legendLabel`) allows toggling the visibility of all period highlights.
- Date Snapping: Start and end dates for periods snap to the nearest available dates on the chart's x-axis.

Changes include:
- New default options for `periodHighlights` in `PureChart.js`.
- Modifications to legend drawing (`_drawLegend`) and click handling (`_onCanvasClick`) to support the global toggle.
- New helper method `_findXCoordinateForDate` to map 'YYYY-MM-DD' strings to x-axis coordinates.
- New core drawing method `_drawPeriodHighlights` to render the rectangles and labels.
- Integration of `_drawPeriodHighlights` into the main `_draw` cycle.
- A new demo in `PureChart/demo_full.html` showcasing the feature.
- Comprehensive documentation in `PureChart/README.md`.