### PR TITLE
Feat: Enhance Panorama block menu functionality and appearance

### DIFF
--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -131,19 +131,23 @@ html, body {
 }
 
 .panorama-item-menu-btn {
-  background-color: #f8f9fa; 
-  border: 1px solid #ced4da; 
-  color: #495057; 
-  padding: 4px 8px; 
-  font-size: 1.2em; /* Standard font size for '⋮' */
+  background-color: transparent;
+  border: none;
+  color: #495057; /* Keep original icon color */
+  padding: 2px; /* Significantly reduce padding */
+  font-size: 1.2em; 
   line-height: 1; 
-  border-radius: 4px;
+  border-radius: 4px; /* Keep for slightly rounded hover effect if color changes */
   cursor: pointer;
+  /* Adding position relative and z-index to ensure it's clickable if other elements overlap */
+  position: relative; 
+  z-index: 1;
 }
 
 .panorama-item-menu-btn:hover {
-  background-color: #e9ecef;
-  border-color: #adb5bd; 
+  background-color: transparent; /* Ensure no background on hover */
+  border: none; /* Ensure no border on hover */
+  color: #007bff; /* Change icon color on hover for feedback */
 }
 
 .panorama-item-menu-popup {
@@ -171,6 +175,11 @@ html, body {
 
 .panorama-item-menu-popup a:hover {
   background-color: #f8f9fa;
+}
+
+.panorama-item-menu-popup.open-upwards {
+  top: auto; /* Override the default top */
+  bottom: 100%; /* Position bottom of popup at the top of the button's container */
 }
 
 /* New Resize Handles Styling */


### PR DESCRIPTION
This commit addresses your feedback on the Panorama block menus:

1.  **Fix Menu Display for Tables and Charts:**
    *   Modified `_renderTable` and `_renderChart` in `Panorama/panorama.js`.
    *   These functions now use dedicated child 'host' divs for their content (tables or charts).
    *   This prevents the item controls (menu button and popup) from being overwritten when table or chart content is rendered or cleared, ensuring menus are consistently available.

2.  **Icon-Only Menu Button:**
    *   Updated CSS for `.panorama-item-menu-btn` in `Panorama/panorama.css`.
    *   Set button background to transparent and border to none.
    *   Reduced padding and updated hover styles to only change icon color, making the button appear as a '⋮' icon.

3.  **Dynamic Popup Positioning (Upwards Opening):**
    *   Enhanced the menu button's click listener in `Panorama/panorama.js`.
    *   The popup menu now checks available viewport space before displaying.
    *   If there's insufficient space below the button and enough space above, it adds an `open-upwards` class.
    *   Added corresponding CSS in `Panorama/panorama.css` for `.panorama-item-menu-popup.open-upwards` to position the popup above the button.
    *   This prevents the popup from being clipped at the bottom of the viewport.