### PR TITLE
Feat: Implement block sizing enhancements and 'Fit to Text'

### DIFF
--- a/Panorama/PanoramaGrid.css
+++ b/Panorama/PanoramaGrid.css
@@ -31,7 +31,7 @@
     justify-content: flex-start; /* Changed from center to allow natural top-to-bottom flow */
     align-items: stretch;       /* Changed from center to allow content to take full width */
     flex-grow: 1;
-    overflow: auto; /* Allow scrolling for content that exceeds the item's bounds */
+    overflow: hidden; /* Prevent scrollbars on the content area itself */
     height: 100%; /* Ensure it utilizes the height of .panorama-grid-custom-item */
     box-sizing: border-box; /* Padding should not add to the 100% height */
 }

--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -182,6 +182,21 @@ html, body {
   bottom: 100%; /* Position bottom of popup at the top of the button's container */
 }
 
+.panorama-fit-text-btn {
+  background-color: transparent;
+  border: none;
+  color: #495057; /* Match menu button color */
+  padding: 2px; /* Match menu button padding */
+  font-size: 1em; /* Adjust as needed, might be smaller than menu icon */
+  line-height: 1;
+  cursor: pointer;
+  margin-left: 5px; /* Space it from the menu button */
+}
+
+.panorama-fit-text-btn:hover {
+  color: #007bff; /* Match menu button hover color */
+}
+
 /* New Resize Handles Styling */
 .panorama-item .resize-handle-base { /* Base style for all handles */
   position: absolute;


### PR DESCRIPTION
This commit introduces several improvements to Panorama item sizing and text handling:

1.  **Minimum Block Size:**
    *   `PanoramaGrid.js` now enforces a minimum item size of 2x2 grid units.
    *   This applies during user resizing and when new items are added via `addItem` or `loadLayout`.

2.  **No Scrollbars on Blocks:**
    *   Set `overflow: hidden` on the `.panorama-grid-custom-item-content` class in `PanoramaGrid.css`.
    *   This prevents scrollbars from appearing on the main content area of items if their internal content (text, tables, charts) overflows. Content will be clipped instead.

3.  **'Fit to Text' Button for Text Items:**
    *   Added a 'Fit' button to the controls of text items in `Panorama/panorama.js`.
    *   Clicking this button calculates the necessary height to display all text content within the item's current width and resizes the item accordingly using `this.grid.updateItemLayout()`.
    *   Introduced a `.text-host` div within text items for more robust text management and measurement.
    *   Added CSS for the new button in `Panorama/panorama.css`.