### PR TITLE
Fix: Ensure Panorama menu is visible above item content

### DIFF
--- a/Panorama/PanoramaGrid.css
+++ b/Panorama/PanoramaGrid.css
@@ -31,7 +31,7 @@
     justify-content: flex-start; /* Changed from center to allow natural top-to-bottom flow */
     align-items: stretch;       /* Changed from center to allow content to take full width */
     flex-grow: 1;
-    overflow: hidden; /* Prevent scrollbars on the content area itself */
+    overflow: visible; /* Prevent scrollbars on the content area itself */
     height: 100%; /* Ensure it utilizes the height of .panorama-grid-custom-item */
     box-sizing: border-box; /* Padding should not add to the 100% height */
 }


### PR DESCRIPTION
I changed `overflow: hidden` to `overflow: visible` on the `.panorama-grid-custom-item-content` class in `PanoramaGrid.css`. This prevents the item content container from clipping the menu popup, allowing the menu to be fully visible even if the item block is small.

I reviewed `z-index` values and confirmed that the existing `z-index: 120` for `.panorama-item-menu-popup` is sufficient to keep the menu above other item elements like resize handles.