### PR TITLE
Fix: Prevent menu clipping and content overflow in Panorama

### DIFF
--- a/Panorama/PanoramaGrid.css
+++ b/Panorama/PanoramaGrid.css
@@ -31,7 +31,7 @@
     justify-content: flex-start; /* Changed from center to allow natural top-to-bottom flow */
     align-items: stretch;       /* Changed from center to allow content to take full width */
     flex-grow: 1;
-    overflow: visible; /* Prevent scrollbars on the content area itself */
+    overflow: hidden; /* Prevent scrollbars on the content area itself */
     height: 100%; /* Ensure it utilizes the height of .panorama-grid-custom-item */
     box-sizing: border-box; /* Padding should not add to the 100% height */
 }

--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -119,13 +119,16 @@ html, body {
   flex-grow: 1;
 }
 
-/* Item Controls Styling (Menu Button and Popup) - Placed inside panorama-item-content */
+/* Item Controls Styling (Menu Button and Popup) - Positioned absolutely within .panorama-item */
 .panorama-item-controls {
-  position: relative; 
+  position: absolute; /* Changed from relative */
+  top: 0; /* Added */
+  right: 0; /* Added */
+  z-index: 10; /* Added */
   display: flex;
-  justify-content: flex-end; /* Changed to flex-end to align button to the right */
+  justify-content: flex-end; /* Align button to the right */
   align-items: flex-start; /* Ensure alignment to the top */
-  padding: 5px; /* Uniform padding for spacing from top and right */
+  padding: 5px; /* Kept for spacing from edges and for button */
   background-color: transparent; 
   border-top: none; 
 }

--- a/Panorama/panorama.js
+++ b/Panorama/panorama.js
@@ -67,7 +67,7 @@ class Panorama {
             if (!controlsContainer) {
                 controlsContainer = document.createElement('div');
                 controlsContainer.className = 'panorama-item-controls';
-                contentContainerElement.insertBefore(controlsContainer, contentContainerElement.firstChild); // Prepend to contentContainerElement
+                const itemElement = contentContainerElement.parentElement; itemElement.appendChild(controlsContainer);
             } else {
                 controlsContainer.innerHTML = ''; // Clear old buttons if re-rendering
             }


### PR DESCRIPTION
- Modified `Panorama.js` to append the `.panorama-item-controls` div (which contains the menu button and popup) as a direct child of the main item element (`.panorama-grid-custom-item`). This item element has `overflow: visible`.
- Adjusted the CSS for `.panorama-item-controls` in `panorama.css` to use `position: absolute`, `top: 0`, `right: 0`, and `z-index: 10`. This positions the controls container at the top-right of the item tile, above other content within the tile.

This resolves the issue where the menu popup was clipped by the item's content container (which has `overflow: hidden`). The menu popup can now render outside the bounds of the content container but remains correctly positioned relative to its button. This also avoids the previous issue where setting `overflow: visible` on the content container caused the actual block content (text, images, etc.) to overflow its bounds.