### PR TITLE
Fix: Correctly update and re-render items on configuration change

### DIFF
--- a/Panorama/panorama.js
+++ b/Panorama/panorama.js
@@ -286,7 +286,7 @@ class Panorama {
 
     // Call PanoramaGrid's method, which will update its internal config and re-render content.
     if (this.grid) { // Check if grid exists before calling its method
-        this.grid.updateItemContent(itemId, fullNewConfig);
+        this.grid.updateItemConfiguration(itemId, fullNewConfig);
     } else {
         console.error("Panorama.updateItemConfig: this.grid is not initialized.");
     }


### PR DESCRIPTION
Previously, editing an item and saving the changes would result in an 'Unsupported Content Type' error. This was because `Panorama.js` was calling `PanoramaGrid.js`'s `updateItemContent` method with a full configuration object, while `updateItemContent` expected simple, directly renderable content.

This commit introduces the following changes:
1.  Added a new method `updateItemConfiguration(itemId, newFullConfig)` to `PanoramaGrid.js`. This method is specifically designed to handle updates to an item's full configuration. It updates the item's stored config object (preserving layout information) and then calls the `renderItemContent` callback to re-render the item's content based on the new configuration.
2.  Modified `Panorama.js`'s `updateItemConfig` method to call the new `this.grid.updateItemConfiguration(itemId, fullNewConfig)` method instead of the incorrect `updateItemContent`.

This ensures that item content is properly re-rendered after an edit, resolving the reported bug.