### PR TITLE
Fix: Correct item data structure for save and load functionality

### DIFF
--- a/Panorama/PanoramaGrid.js
+++ b/Panorama/PanoramaGrid.js
@@ -1004,20 +1004,31 @@ class PanoramaGrid {
             // For now, shallow copies via spread operator are used for layout.
             // Deep copy for config to handle nested objects/arrays, assuming JSON serializable content.
             // Functions or live DOM elements in config.content won't serialize with JSON.stringify.
-            let serializableConfig = {};
+            let specificConfig = {};
             try {
                 // Attempt deep copy for config, but handle potential non-serializable content gracefully.
-                // This basic deep copy won't handle functions or DOM elements in config.
-                serializableConfig = JSON.parse(JSON.stringify(itemObject.config));
+                specificConfig = JSON.parse(JSON.stringify(itemObject.config));
             } catch (e) {
                 console.warn(`PanoramaGrid: Could not fully serialize config for item ID ${itemObject.id} due to non-JSON content. Proceeding with a shallow copy.`, e);
-                serializableConfig = { ...itemObject.config }; // Fallback to shallow copy
+                specificConfig = { ...itemObject.config }; // Fallback to shallow copy
             }
+
+            // Extract type from the original config (less prone to issues if type was complex)
+            const itemType = itemObject.config.type; 
+            
+            // The authoritative layout is itemObject.layout
+            const authoritativeLayout = { ...itemObject.layout };
+
+            // Remove 'type' and 'layout' from the specificConfig object
+            // as they are now top-level properties in the serialized item.
+            delete specificConfig.type;
+            delete specificConfig.layout; // Deletes layout if it was part of the itemObject.config structure
 
             return {
                 id: itemObject.id,
-                config: serializableConfig,
-                layout: { ...itemObject.layout }
+                type: itemType,
+                config: specificConfig, // This is now the type-specific config
+                layout: authoritativeLayout
             };
         });
 


### PR DESCRIPTION
Previously, loading a saved dashboard failed because the `type` property of items was nested within the `config` object, while `loadLayout` expected `type` to be a top-level property. Additionally, the `config` object saved was the entire item configuration, not just the type-specific fields.

This commit modifies the `getLayout` method in `PanoramaGrid.js` to serialize items in the correct structure:
- `type` is now a top-level property.
- `layout` is a top-level property, using the authoritative item layout.
- `config` now contains only the type-specific configuration fields (e.g., for a 'text' item, it would be `{ content: '...' }`).

This change ensures that the data structure used during save is consistent with the structure expected by `loadLayout` and `addItem`, resolving the 'Skipping item in loadLayout' error and allowing dashboards to be saved and loaded correctly.