### PR TITLE
Fix: Improve X-axis label spacing for first and last labels

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -1397,20 +1397,52 @@ class PureChart {
                     const labelText = String(labels[index]);
                     this.ctx.font = oX.labelFont;
                     const labelWidth = this.ctx.measureText(labelText).width;
+
+                    // Default xPos for all labels, calculated based on their slot.
+                    // xLabelSlotWidth is (this.drawArea.width / numLabels)
                     let xPos = this.drawArea.x + (index * xLabelSlotWidth) + (xLabelSlotWidth / 2);
 
+                    // If forcing first/last, specifically adjust their xPos.
+                    // Intermediate labels will keep their slot-based xPos.
+                    if (forceShowFirstAndLast) {
+                        if (index === 0) {
+                            // Align first label's center so its left edge is near drawArea.x.
+                            xPos = this.drawArea.x + labelWidth / 2;
+                            // If it's the only label, ensure it's centered in the drawArea.
+                            if (numLabels === 1) {
+                                xPos = this.drawArea.x + this.drawArea.width / 2;
+                            }
+                        } else if (index === numLabels - 1) {
+                            // Align last label's center so its right edge is near drawArea.x + drawArea.width.
+                            xPos = this.drawArea.x + this.drawArea.width - labelWidth / 2;
+                        }
+                    }
+
+                    // Recalculate currentLabelStartX and currentLabelEndX based on the potentially adjusted xPos.
                     let currentLabelStartX = xPos - labelWidth / 2;
                     let currentLabelEndX = xPos + labelWidth / 2;
 
-                    if (forceShowFirstAndLast) {
-                        if (index === 0 && currentLabelStartX < this.drawArea.x) {
-                            xPos = this.drawArea.x + labelWidth / 2;
-                        } else if (index === numLabels - 1 && currentLabelEndX > this.drawArea.x + this.drawArea.width) {
-                            xPos = this.drawArea.x + this.drawArea.width - labelWidth / 2;
+                    // Boundary collision checks and adjustments.
+                    // Applied to all labels, but especially important for first/last after pinning.
+
+                    // Case 1: Label is pushed too far left
+                    if (currentLabelStartX < this.drawArea.x) {
+                        xPos = this.drawArea.x + labelWidth / 2;
+                        if (labelWidth > this.drawArea.width) { // If label is wider than draw area
+                             xPos = this.drawArea.x + this.drawArea.width / 2; // Center the huge label
                         }
-                        currentLabelStartX = xPos - labelWidth / 2; // Recalculate after potential xPos adjustment
-                        currentLabelEndX = xPos + labelWidth / 2;
                     }
+                    // Case 2: Label is pushed too far right
+                    else if (currentLabelEndX > this.drawArea.x + this.drawArea.width) {
+                        xPos = this.drawArea.x + this.drawArea.width - labelWidth / 2;
+                        if (labelWidth > this.drawArea.width) { // If label is wider than draw area
+                            xPos = this.drawArea.x + this.drawArea.width / 2; // Center the huge label
+                        }
+                    }
+
+                    // Final recalculation of start/end after all adjustments
+                    currentLabelStartX = xPos - labelWidth / 2;
+                    currentLabelEndX = xPos + labelWidth / 2;
 
                     let drawThisLabel = true;
 


### PR DESCRIPTION
This commit addresses an issue where the first and last labels on the X-axis could appear too far from the edges of the chart and from other labels, especially when `forceShowFirstAndLastLabel` is true and few labels are displayed.

The `_drawAxesAndGrid` method in `PureChart.js` has been updated to:
- When `forceShowFirstAndLastLabel` is true, the first label is now positioned with its center aligned so its left edge is near the start of the drawing area.
- Similarly, the last label is positioned with its center aligned so its right edge is near the end of the drawing area.
- Intermediate labels continue to be positioned based on their calculated slots.
- Boundary adjustments are maintained to prevent labels from being drawn off-canvas and to center labels that are wider than the drawing area.

A new test case (Test 11) has been added to `PureChart/tests/label-filtering.test.js` to specifically verify this improved positioning. The test utility's (`TestPureChart`) `_drawAxesAndGrid` method was also updated to align with the new logic in `PureChart.js` to ensure accurate testing.

This change results in more visually consistent and appealing label distribution for charts utilizing the `forceShowFirstAndLastLabel` option.