### PR TITLE
Here's the revised message:

### DIFF
--- a/Panorama/PanoramaGrid.css
+++ b/Panorama/PanoramaGrid.css
@@ -8,7 +8,7 @@
     background-color: #f0f0f0; /* Example background */
     border: 1px solid #d0d0d0;
     border-radius: 4px;
-    min-height: 200px; /* Example minimum height */
+    /* min-height: 200px; */ /* Example minimum height */
 }
 
 .panorama-grid-custom-item {
@@ -18,6 +18,7 @@
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
     overflow: visible; /* Ensures popups are not clipped */
     position: relative; /* For potential absolute positioned children or pseudo-elements */
+    box-sizing: border-box;
 
     /* Grid positioning will be set by JS via style attributes:
        grid-column-start, grid-row-start, grid-column-end, grid-row-end (or spans)

--- a/Panorama/PanoramaGrid.js
+++ b/Panorama/PanoramaGrid.js
@@ -54,26 +54,11 @@ class PanoramaGrid {
     }
 
     _calculateCurrentRowHeight() {
-        if (!this.containerElement || this.containerElement.clientHeight <= 0 || this.options.targetRowCount <= 0) {
-            this.currentRowHeight = this.options.rowHeight; // Fallback to initial fixed option
-            // console.warn("PanoramaGrid: Could not calculate dynamic row height (clientHeight or targetRowCount invalid), using fallback:", this.currentRowHeight);
-            return;
-        }
-        const containerHeight = this.containerElement.clientHeight;
-        // Assuming gap is only between rows, so (targetRowCount - 1) gaps.
-        // Also assuming container clientHeight does not include its own top/bottom padding. If it does, those should be subtracted.
-        const totalGapSpace = Math.max(0, (this.options.targetRowCount - 1) * this.options.gap);
-        const heightAvailableForRowContent = containerHeight - totalGapSpace;
-
-        let calculatedHeight = heightAvailableForRowContent / this.options.targetRowCount;
-        // Apply lower bound
-        calculatedHeight = Math.max(10, calculatedHeight);
-
-        // Apply upper cap
-        const maxAllowedRowHeight = this.options.rowHeight * 1.5;
-        this.currentRowHeight = Math.min(calculatedHeight, maxAllowedRowHeight);
-        
-        // console.log('PanoramaGrid: Calculated new currentRowHeight:', this.currentRowHeight);
+        // With a fixed container height and desire for fixed row heights,
+        // directly use the rowHeight option.
+        // The container will scroll if items exceed its fixed height.
+        this.currentRowHeight = this.options.rowHeight;
+        // console.log('PanoramaGrid: Set currentRowHeight to fixed value:', this.currentRowHeight);
     }
 
     _debounce(func, delay) {

--- a/Panorama/panorama.css
+++ b/Panorama/panorama.css
@@ -58,6 +58,8 @@ html, body {
   background-color: #e9ecef; 
   border: 1px solid #ced4da; 
   border-radius: 4px;
+  height: 600px;
+  overflow: auto;
   /* New CSS Grid styles -- These are now controlled by PanoramaGrid.js and PanoramaGrid.css */
   /* display: grid; */
   /* grid-template-columns: repeat(12, 1fr); */ /* 12-column grid */


### PR DESCRIPTION
Fix: Panorama grid layout adjustments for fixed height and spacing.

This commit addresses two layout issues in the Panorama grid:

1.  **Fixed Container Height:**
    - The Panorama grid container (`#panorama-grid-container`) now has a fixed height (600px) and will display a vertical scrollbar if its content overflows. This prevents the container from adjusting its height based on content.
    - CSS changes were made in `panorama.css` to set `height: 600px;` and `overflow: auto;` on `#panorama-grid-container`.
    - The `min-height` property on `.panorama-grid-custom-container` in `PanoramaGrid.css` was commented out.

2.  **Consistent Vertical Spacing:**
    - The vertical spacing between blocks is now fixed and equal to the horizontal spacing.
    - I simplified `_calculateCurrentRowHeight()` in `PanoramaGrid.js` to use `this.options.rowHeight` directly, ensuring a fixed and consistent row height.
    - I added `box-sizing: border-box;` to `.panorama-grid-custom-item` in `PanoramaGrid.css`. This ensures that item borders and padding are included in their calculated height, leading to accurate visual spacing based on the CSS Grid `gap` property.

These changes ensure a more stable and predictable layout for the Panorama grid.