### PR TITLE
Fix: Hide 'Economic Event' series by default in Period Highlighting c…

### DIFF
--- a/PureChart/demo_full.html
+++ b/PureChart/demo_full.html
@@ -921,7 +921,7 @@
                     xAxis: { title: 'Date' },
                     yAxis: { title: 'Price', beginAtZero: false },
                     periodHighlights: {
-                        display: true, 
+                        display: false,
                         legendLabel: "Economic Events",
                         periods: [
                             {


### PR DESCRIPTION
…hart.

The 'Economic Event' series (periodHighlights) in the 'Line Chart with Period Highlighting' on the demo_full.html page was previously visible by default.

This change modifies the chart's configuration to set `periodHighlights.display` to `false`, ensuring that these events are hidden on initial load. The existing legend click functionality correctly toggles their visibility.