### PR TITLE
Fix: Correct legend interaction for initially hidden period highlights.

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -970,8 +970,7 @@ class PureChart {
         }));
 
         // Add legend item for period highlights toggle
-        if (this.config.options.periodHighlights && 
-            this.config.options.periodHighlights.display && // Check if global display is true
+        if (this.config.options.periodHighlights &&
             this.config.options.periodHighlights.periods && 
             this.config.options.periodHighlights.periods.length > 0 && 
             this.config.options.periodHighlights.legendLabel) {


### PR DESCRIPTION
The "Economic Event" series (periodHighlights) in the 'Line Chart with Period Highlighting' was not correctly hiding by default and its legend item was not interactive when `periodHighlights.display` was set to `false` in the chart configuration.

This was because the `_drawLegend` function in `PureChart.js` incorrectly used the `periodHighlights.display` configuration property to determine whether to *create* the legend item. If `display` was `false`, the legend item was not created, making it impossible for you to click and toggle visibility.

This commit fixes `_drawLegend` to always create the legend item for `periodHighlights` if the feature is configured (i.e., `legendLabel` and `periods` are provided), regardless of the initial `display` setting. The initial visibility of the highlights is still controlled by `periodHighlights.display` (via `this.showPeriodHighlights` in the constructor), and the legend item's visual state (e.g., strikethrough) correctly reflects `this.showPeriodHighlights`.

With this change:
- Setting `periodHighlights.display: false` in `demo_full.html` now correctly hides the "Economic Event" series by default.
- The "Economic Event" legend item is always present and interactive, allowing you to toggle the visibility of the series.