### PR TITLE
Fix: Enable correct click interaction for period highlights legend.

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -1010,7 +1010,7 @@ class PureChart {
                 w: itemSegmentWidth,
                 h: itemHeight
             };
-            this.interactiveLegendItems.push({ rect: legendItemRect, dataset: item.dataset, datasetIndex: item.datasetIndex });
+            this.interactiveLegendItems.push({ rect: legendItemRect, dataset: item.dataset, datasetIndex: item.datasetIndex, isPeriodToggle: item.isPeriodToggle || false });
 
             this.ctx.fillStyle = item.color;
             if (legend.markerStyle === 'circle') {


### PR DESCRIPTION
The "Economic Event" series (periodHighlights) was correctly made hidden by default in a previous step, and its legend item was being created. However, clicking the legend item still did not toggle its visibility.

This was due to the `isPeriodToggle` flag not being correctly propagated to the `interactiveLegendItems` array within the `_drawLegend` function. As a result, the `_onCanvasClick` function could not identify the "Economic Event" legend item as the special toggle item.

This commit modifies `_drawLegend` in `PureChart.js` to ensure that the `isPeriodToggle` property is copied from the `legendItemsData` (where it's correctly set for the period highlights legend entry) to the corresponding object in `this.interactiveLegendItems`.

With this change:
- The "Economic Event" legend item is now correctly identified upon click.
- Clicking the legend item successfully toggles the `this.showPeriodHighlights` state and triggers a redraw.
- The visibility of the period highlight areas on the chart and the visual state of the legend item (strikethrough/normal) now correctly update in response to clicks.
- The series remains hidden by default as per the configuration (`periodHighlights.display: false` in `demo_full.html`).