### PR TITLE
Fix: Apply no-wrap to currency/percentage and min-width to charts

### DIFF
--- a/Dynamic-table/dynamic-table.css
+++ b/Dynamic-table/dynamic-table.css
@@ -1010,6 +1010,11 @@
 /* Checkboxes in .dt-column-selector-item might need specific styling for dark mode */
 /* .dt-dark-mode .dt-column-selector-item input[type="checkbox"] { ... } */
 
+.dynamic-table tbody td.dt-currency-cell,
+.dynamic-table tbody td.dt-percentage-cell {
+    white-space: nowrap;
+}
+
 /* === Dark Mode Styles === */
 .dt-dark-mode.dynamic-table-wrapper {
     background-color: var(--dt-dark-bg-primary);

--- a/Dynamic-table/dynamic-table.js
+++ b/Dynamic-table/dynamic-table.js
@@ -1292,6 +1292,14 @@ function createDynamicTable(config) {
 
                     const cell = row.insertCell();
                     cell.innerHTML = ''; // Clear previous content
+
+                    if (typeof colConfig.format === 'string') {
+                        if (colConfig.format.startsWith('currency:')) {
+                            cell.classList.add('dt-currency-cell');
+                        } else if (colConfig.format.startsWith('percent')) { // This will catch 'percent' and 'percent_neutral'
+                            cell.classList.add('dt-percentage-cell');
+                        }
+                    }
                     
                     const value = item[colConfig.key];
 
@@ -1303,6 +1311,10 @@ function createDynamicTable(config) {
                         // Create inner wrapper for canvas
                         const canvasWrapper = document.createElement('div');
                         canvasWrapper.className = 'dt-chart-canvas-wrapper';
+
+                        const chartWidth = colConfig.chartConfig.width || 150; // Get configured width, default to 150
+                        canvasWrapper.style.minWidth = chartWidth + 'px';
+
                         cell.appendChild(canvasWrapper);
 
                         const canvasId = `${containerId}-chart-${startIndex + itemIndex}-${colIndexOriginal}`; // Use original index for unique ID


### PR DESCRIPTION
This commit addresses two layout issues in the dynamic table:

1.  Percentage and Currency Column Wrapping:
    - Cells in columns formatted as 'currency' or 'percentage' (including 'percent_neutral') will no longer wrap their content.
    - This is achieved by adding `dt-currency-cell` and `dt-percentage-cell` classes to the respective `<td>` elements in JavaScript.
    - New CSS rules in `dynamic-table.css` apply `white-space: nowrap;` to these classes.

2.  Chart Minimum Width:
    - Chart canvases will no longer shrink below their configured width.
    - The `div` wrapper around the chart canvas (`.dt-chart-canvas-wrapper`) now has an inline `min-width` style applied in JavaScript, corresponding to the `chartConfig.width`.
    - This ensures the chart's visual integrity even in constrained table layouts.