### PR TITLE
fix: Correct toolbar display and handle image loading for layout

### DIFF
--- a/Mindmap/index.html
+++ b/Mindmap/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../PureChart/PureChart.css">
 </head>
 <body>
-  <div id="controls">
+  <div id="toolbar">
     <input type="text" id="node-text-input" placeholder="Enter node text">
     <button id="add-node-btn">Add Node to Root</button>
     <button id="save-locally-btn">Save Locally</button>

--- a/Mindmap/mindmap.js
+++ b/Mindmap/mindmap.js
@@ -940,7 +940,29 @@ function createNodeElement(nodeData) {
   if (nodeData.image && nodeData.image.src) {
     const imgElement = document.createElement('img');
     imgElement.classList.add('node-image');
-    imgElement.src = nodeData.image.src; imgElement.alt = nodeData.image.alt || 'Node image';
+    imgElement.src = nodeData.image.src;
+    imgElement.alt = nodeData.image.alt || 'Node image';
+
+    imgElement.onload = () => {
+        console.log(`Image loaded: ${nodeData.image.src}, for node: ${nodeData.id}. Triggering re-render.`);
+        // It's crucial to ensure that the nodeData itself isn't stale if renderMindmap
+        // operates on a global mindmapData object that might have been updated elsewhere.
+        // renderMindmap takes the main mindmapData object as an argument.
+        // We use window.mindmapData to ensure we're always passing the latest global state.
+        if (window.mindmapData && typeof renderMindmap === 'function') {
+            renderMindmap(window.mindmapData, 'mindmap-container');
+        } else {
+            console.error("renderMindmap or window.mindmapData not available for image onload handler.");
+        }
+    };
+
+    imgElement.onerror = () => {
+        console.error(`Failed to load image: ${nodeData.image.src}, for node: ${nodeData.id}.`);
+        // Optionally, trigger re-render if broken image icon or alt text causes size changes.
+        // For now, no re-render on error, to avoid potential loops if server keeps erroring.
+        // If alt text styling is significant, a re-render might be considered.
+    };
+
     nodeElement.appendChild(imgElement);
   }
   if (nodeData.notes) {


### PR DESCRIPTION
This commit addresses two key issues:

1.  **Toolbar Display**:
    - Fixed a CSS bug where the main controls div in `index.html` had an incorrect ID (`controls` instead of `toolbar`), preventing toolbar styles from being applied. The ID has been corrected to `toolbar`, ensuring the toolbar and its buttons (including "New/Clear Map") are displayed as intended.

2.  **Image Loading Impact on Layout**:
    - Modified `createNodeElement` to add an `onload` event handler to images within mindmap nodes.
    - When an image finishes loading, `renderMindmap()` is now called to re-calculate all node/subtree dimensions and re-apply the tree layout. This ensures the layout accurately reflects node sizes after images are loaded, preventing overlaps that could occur if layout was based on pre-load (incorrect) dimensions.

These changes improve the UI consistency by fixing the toolbar and enhance layout stability by properly accounting for asynchronously loaded images.