### PR TITLE
feat: Major layout improvements, zoom-to-fit, and UI fixes

### DIFF
--- a/Mindmap/index.html
+++ b/Mindmap/index.html
@@ -16,6 +16,7 @@
     <button id="clear-local-storage-btn">Clear Local Data</button>
     <button id="save-to-server-btn">Save to Server (Sim)</button> <!-- Text updated slightly -->
     <button id="load-from-server-btn">Load from Server (Sim)</button>
+    <button id="zoom-to-fit-btn">Zoom to Fit</button>
     <hr style="margin: 5px 0;">
     <div>
       <label for="import-file-input">Import from JSON File:</label>
@@ -24,6 +25,9 @@
   </div>
   <div id="feedback-message" class="feedback-message" style="display:none;"></div>
   <div id="mindmap-container">
+    <div id="mindmap-content-wrapper" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+      <!-- Nodes will be appended here by JavaScript -->
+    </div>
     <svg id="mindmap-svg-layer"></svg>
   </div>
 


### PR DESCRIPTION
This commit includes a series of significant updates:

1.  **UI Fix - Toolbar Display**:
    - Corrected an HTML ID mismatch (`controls` to `toolbar`) that prevented the main control bar from being styled correctly. This ensures all toolbar buttons, including "New/Clear Map", are now consistently visible and styled.

2.  **Layout Stability - Asynchronous Content Handling**:
    - Implemented a delayed re-render mechanism for nodes containing charts (similar to a previous fix for images). If charts are present, a secondary layout pass is triggered after a short delay (250ms). This allows `PureChart.js` time to render, ensuring more accurate node dimensions are used for layout, which should significantly reduce node overlap issues.

3.  **New Feature - Zoom-to-Fit**:
    - Added a "Zoom to Fit" button to the toolbar.
    - Implemented functionality to calculate the bounding box of all visible mindmap nodes and then apply a CSS scale and translate transform to a new `#mindmap-content-wrapper`.
    - Connection lines are redrawn immediately after the zoom/pan transform to accurately connect to the new node positions.
    - Note: This zoom state is not currently persisted across full mindmap re-renders (e.g., after adding a new node).

4.  **Testing**:
    - Added unit tests for the core calculation logic of the "Zoom-to-Fit" feature, including bounding box calculation and transform parameter derivation.

5.  **Code Cleanup**:
    - Removed all temporary diagnostic CSS and console.log statements that were added during previous debugging phases.

These changes aim to resolve persistent user feedback regarding UI element visibility (clear button) and node overlapping, while also introducing a valuable new zoom capability.