### PR TITLE
fix: Adjust padding for pill chart demo to prevent "Drawing area too …

### DIFF
--- a/PureChart/pill_chart_example.json
+++ b/PureChart/pill_chart_example.json
@@ -10,7 +10,7 @@
     },
     "width": 600,
     "height": 120,
-    "padding": { "top": 40, "right": 50, "bottom": 40, "left": 50 },
+    "padding": { "top": 20, "right": 50, "bottom": 20, "left": 50 },
     "pill": {
       "min": 0,
       "max": 100,


### PR DESCRIPTION
…small"

The pill chart in the demo (demo_full.html) was not displaying due to the calculated drawing area height being too small (1px). This was caused by the combination of the canvas height (120px), top/bottom padding (40px each), and the height of the displayed title.

This commit adjusts the top and bottom padding in
`PureChart/pill_chart_example.json` from 40px to 20px each. This change provides sufficient vertical space for the pill chart (with a configured pillHeight of 40px) to render correctly within the calculated drawing area.

The `_getDrawingArea` method in PureChart.js was found to be correctly handling the pill chart type by not subtracting space for axes or legends (as their display properties are false for this chart type). The issue was purely in the demo's configuration.