### PR TITLE
diag: Update HTML diagnostic banner to V2 for robust visibility

### DIFF
--- a/Mindmap/index.html
+++ b/Mindmap/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../PureChart/PureChart.css">
 </head>
 <body>
-<h1 style="background-color: yellow; color: red; font-size: 28px; text-align: center; padding: 15px; border: 5px solid blue; position: fixed; top: 45%; left: 50%; transform: translate(-50%, -50%); z-index: 1000000; width: 80%; box-shadow: 10px 10px 5px grey;">TESTING - LATEST UPDATE CODE VERSION: HTML_BANNER_V1</h1>
+<h1 style="background-color: magenta !important; color: white !important; font-size: 24px !important; text-align: center !important; padding: 20px !important; border: 5px solid limegreen !important; position: fixed !important; top: 150px !important; left: 10px !important; width: calc(100% - 40px) !important; min-height: 50px !important; z-index: 2000000 !important; box-shadow: 10px 10px 5px grey !important; overflow: visible !important;">TESTING - LATEST UPDATE CODE VERSION: HTML_BANNER_V2 - IS THIS VISIBLE?</h1>
   <div id="toolbar">
     <input type="text" id="node-text-input" placeholder="Enter node text">
     <button id="add-node-btn">Add Node to Root</button>


### PR DESCRIPTION
This commit modifies the HTML-only diagnostic banner in `Mindmap/index.html`.

The banner (HTML_BANNER_V1) from the previous diagnostic attempt was reported by you as being in the code but "crushed" or hidden by a subsequent div, despite a high z-index.

This V2 banner features:
- Different, highly prominent inline styles (magenta background, limegreen border, white text).
- Removal of CSS `transform: translate(-50%, -50%)` to simplify positioning.
- Explicit `top: 150px; left: 10px;` fixed positioning.
- Explicit `width: calc(100% - 40px);` and `min-height: 50px !important;`.
- Increased `z-index: 2000000 !important;`.
- Added `overflow: visible !important;`.
- Updated text to "TESTING - LATEST UPDATE CODE VERSION: HTML_BANNER_V2 - IS THIS VISIBLE?".

These changes aim to make the banner extremely difficult to obscure if the `index.html` file is being loaded correctly, by simplifying its rendering requirements and further increasing its visual prominence. No changes were made to CSS or JS files in this commit.