### PR TITLE
fix: Correct _getDrawingArea logic for pill charts

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -683,7 +683,7 @@ class PureChart {
         }
 
         // Legend height (if not percentageDistribution)
-        if (options.legend.display && this.config.type !== 'percentageDistribution') {
+        if (options.legend.display && this.config.type !== 'percentageDistribution' && this.config.type !== 'pill') {
             this.ctx.font = options.legend.font;
             const legendHeight = ((this.ctx.measureText('M').width * 1.5) + options.legend.padding) * 2.1;
             if (options.legend.position === 'top') {
@@ -694,7 +694,7 @@ class PureChart {
         }
 
         // Axes space (if not percentageDistribution)
-        if (this.config.type !== 'percentageDistribution') {
+        if (this.config.type !== 'percentageDistribution' && this.config.type !== 'pill') {
             let dynamicLeftPadding = 0;
             let dynamicRightPadding = 0;
 


### PR DESCRIPTION
This commit fixes the _getDrawingArea method in PureChart.js to ensure that space for legends and axes is not deducted when the chart type is 'pill'.

Previously, even though _validateConfig set display properties for legend and axes to false for pill charts, the conditions in _getDrawingArea were too broad and still led to space being subtracted. This resulted in a calculated drawing area height that was too small or negative, preventing the pill chart from rendering.

The conditions for legend and axes space calculation have been updated to explicitly exclude 'this.config.type === "pill"'.

Debug logging for pill chart area calculation remains in place for now to help verify this fix.