### PR TITLE
style: Apply modern styling to pill chart and remove debug logs

### DIFF
--- a/PureChart/pill_chart_example.json
+++ b/PureChart/pill_chart_example.json
@@ -19,12 +19,14 @@
       "value": 75,
       "borderRadius": 20,
       "pillHeight": 40,
+      "pillBorderWidth": 2,
+      "fillLightenPercent": 70,
       "colors": {
-        "mainBackground": "#E0E0E0",
-        "zoneBackground": "#AED581",
-        "cursor": "#F44336",
-        "minMaxText": "#424242",
-        "valueText": "#212121"
+        "mainBackground": "#4A90E2",
+        "zoneBackground": "#50E3C2",
+        "cursor": "#D0021B",
+        "minMaxText": "#4A4A4A",
+        "valueText": "#2F2F2F"
       },
       "cursorThickness": 4,
       "cursorLengthExtension": 8,


### PR DESCRIPTION
This commit introduces a modern styling approach for the 'pill' chart type and cleans up debugging code.

Pill Chart Styling (`_drawPillChart` and `pill_chart_example.json`):
- Added `pillBorderWidth` and `fillLightenPercent` as default options for pill charts in `PureChart.js`.
- The `_drawPillChart` method in `PureChart.js` has been updated:
  - It now uses `pillOptions.colors.mainBackground` as the base/border color for the main pill and `pillOptions.colors.zoneBackground` as the base/border color for the zone.
  - Fill colors for both the main pill and the zone are now calculated by lightening these base colors using the `_lightenColor` helper and the new `fillLightenPercent` option.
  - Borders are drawn on top of the fills if `pillBorderWidth > 0`.
- The `pill_chart_example.json` has been updated to:
  - Use modern, distinct colors for `mainBackground` (e.g., blue) and `zoneBackground` (e.g., teal/green) to serve as border colors.
  - Set `pillBorderWidth: 2`.
  - Update cursor and text colors for a more contemporary look.

Cleanup:
- Removed the temporary `console.log` statements from the `_getDrawingArea` method in `PureChart.js`, which were added for debugging the pill chart's layout issues.

These changes provide the pill chart with a "contour and lighter fill" effect, aligning its visual style more closely with other modern chart elements, and ensure the codebase is clean of temporary debugging logs.