### PR TITLE
feat: Enhance pill chart demos and update JSON example

### DIFF
--- a/PureChart/demo.html
+++ b/PureChart/demo.html
@@ -4,6 +4,35 @@
     <meta charset="UTF-8">
     <title>PureChart Demo - New Features</title>
     <link rel="stylesheet" href="PureChart.css">
+    <style>
+        .pill-chart-row {
+            display: flex;
+            justify-content: space-around;
+            align-items: flex-start; /* Align items at the top */
+            margin-bottom: 20px;
+            flex-wrap: wrap; /* Allow wrapping on smaller screens */
+        }
+        .pill-chart-container {
+            width: 220px; /* Slightly wider to accommodate padding and border */
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            margin: 10px;
+            text-align: center; /* Center the h4 title */
+            background-color: #f9f9f9;
+        }
+        .pill-chart-container h4 {
+            margin-top: 0;
+            margin-bottom: 10px;
+            font-size: 1em;
+            color: #333;
+        }
+        /* Ensure canvases within flex items can shrink if needed, but also respect their attributes */
+        .pill-chart-container canvas {
+            max-width: 100%;
+            height: auto; /* Maintain aspect ratio based on width attribute */
+        }
+    </style>
 </head>
 <body>
     <h1>PureChart Demonstration - New Features</h1>
@@ -28,10 +57,19 @@
     </div>
 
     <!-- New Pill Chart with Zone Overflow and Zone Labels Demo -->
-    <div class="chart-container">
-        <h2>Example 4: Pill Chart with Zone Overflow and Enhanced Zone Labels</h2>
-        <p>This pill chart demonstrates the <code>zoneOverflowAmount</code> option for vertical zone extension, and the <code>showZoneMinMaxLabels</code> feature. It also showcases custom styling for these zone labels, including <code>zoneLabelPosition</code>, <code>zoneLabelColor</code>, <code>zoneLabelFont</code>, <code>zoneLabelOffset</code>, <code>zoneLabelBackgroundColor</code>, and <code>zoneLabelBackgroundPadding</code>.</p>
-        <canvas id="pillOverflowChartCanvas" width="700" height="200"></canvas>
+    <div class="chart-container"> <!-- Keep original h2 and p for the section -->
+        <h2>Example 4: Side-by-Side Pill Charts with Zone Labels</h2>
+        <p>These pill charts demonstrate different <code>zoneLabelPosition</code> options ('above' vs 'on') and custom styling for zone labels. They are displayed side-by-side using flexbox.</p>
+        <div class="pill-chart-row">
+            <div class="pill-chart-container">
+                <h4>Pill Chart 1 (Labels Above)</h4>
+                <canvas id="pillChartDemo1" width="200" height="120"></canvas>
+            </div>
+            <div class="pill-chart-container">
+                <h4>Pill Chart 2 (Labels On Zone)</h4>
+                <canvas id="pillChartDemo2" width="200" height="120"></canvas>
+            </div>
+        </div>
     </div>
 
     <script src="PureChart.js"></script>
@@ -372,40 +410,70 @@
             };
             new PureChart('contourChartCanvas', contourChartConfig);
 
-            // Example 4: Pill Chart with Zone Overflow
-            const pillOverflowConfig = {
+            // Pill Chart Demo 1: Labels Above
+            const pillConfig1 = {
                 type: 'pill',
-                data: {}, // Pill chart data is in options.pill
+                data: {},
                 options: {
-                    title: {
-                        display: true,
-                        text: 'Pill Chart with Zone Overflow (10px)'
-                    },
+                    // No main title for individual small charts, title is in H4
                     pill: {
                         min: 0,
                         max: 100,
-                        value: 65,
-                        zoneMin: 30,
-                        zoneMax: 70,
-                        pillHeight: 25,
-                        borderRadius: 8,
-                        zoneOverflowAmount: 10, // Makes the zone taller
-                        showZoneMinMaxLabels: true, // Show zone labels
-                        zoneLabelPosition: 'above', // Position them above the zone
-                        zoneLabelColor: '#0000CD', // MediumBlue color for zone labels
-                        zoneLabelFont: '12px Arial bold',
-                        zoneLabelOffset: 7,
-                        zoneLabelBackgroundColor: 'rgba(220, 220, 255, 0.75)', // Light blueish background
-                        zoneLabelBackgroundPadding: 3,
+                        value: 75,
+                        zoneMin: 25,
+                        zoneMax: 80,
+                        pillHeight: 20,
+                        borderRadius: 6,
+                        zoneOverflowAmount: 8,
+                        showZoneMinMaxLabels: true,
+                        zoneLabelPosition: 'above',
+                        zoneLabelFont: '10px Arial',
+                        zoneLabelColor: '#333',
+                        zoneLabelOffset: 5,
+                        zoneLabelBackgroundColor: 'rgba(230,230,230,0.7)',
+                        zoneLabelBackgroundPadding: 2,
                         colors: {
-                            mainBackground: '#f0f0f0',
-                            zoneBackground: 'rgba(75, 192, 192, 0.6)', // Teal zone
-                            cursor: '#555'
+                            mainBackground: '#e9ecef',
+                            zoneBackground: '#cfe2ff', // Light blue
+                            cursor: '#0d6efd',
+                            valueText: '#000'
                         }
                     }
                 }
             };
-            new PureChart('pillOverflowChartCanvas', pillOverflowConfig);
+            new PureChart('pillChartDemo1', pillConfig1);
+
+            // Pill Chart Demo 2: Labels On Zone
+            const pillConfig2 = {
+                type: 'pill',
+                data: {},
+                options: {
+                    pill: {
+                        min: 0,
+                        max: 200,
+                        value: 120,
+                        zoneMin: 50,
+                        zoneMax: 150,
+                        pillHeight: 20,
+                        borderRadius: 6,
+                        zoneOverflowAmount: 5,
+                        showZoneMinMaxLabels: true,
+                        zoneLabelPosition: 'on',
+                        zoneLabelFont: '9px Arial bold',
+                        zoneLabelColor: '#ffffff', // White text for on-zone
+                        zoneLabelOffset: 4, // Small offset for 'on'
+                        zoneLabelBackgroundColor: 'rgba(0,0,0,0.3)', // Slightly transparent black bg for contrast
+                        zoneLabelBackgroundPadding: 1,
+                        colors: {
+                            mainBackground: '#e9ecef',
+                            zoneBackground: '#20c997', // Teal/Green
+                            cursor: '#6f42c1', // Purple
+                            valueText: '#000'
+                        }
+                    }
+                }
+            };
+            new PureChart('pillChartDemo2', pillConfig2);
 
         });
     </script>

--- a/PureChart/demo_full.html
+++ b/PureChart/demo_full.html
@@ -4,6 +4,34 @@
     <meta charset="UTF-8">
     <title>PureChart Demo - Full Showcase</title>
     <link rel="stylesheet" href="PureChart.css">
+    <style>
+        .pill-chart-row {
+            display: flex;
+            justify-content: space-around;
+            align-items: flex-start;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+        .pill-chart-container {
+            width: 220px;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            margin: 10px;
+            text-align: center;
+            background-color: #f9f9f9;
+        }
+        .pill-chart-container h4 {
+            margin-top: 0;
+            margin-bottom: 10px;
+            font-size: 1em;
+            color: #333;
+        }
+        .pill-chart-container canvas {
+            max-width: 100%;
+            height: auto;
+        }
+    </style>
 </head>
 <body>
     <h1>PureChart Demonstration - Full Showcase</h1>
@@ -82,6 +110,23 @@
         <h3>Pill Chart with Zone Labels</h3>
         <p>Demonstrates the <code>showZoneMinMaxLabels</code>, <code>zoneLabelPosition</code> (set to 'on' here), and related styling options for displaying values directly on the min/max zones of the pill chart.</p>
         <canvas id="pillZoneLabelsDemoCanvas" width="600" height="120"></canvas>
+    </div>
+
+    <hr style="margin-top: 40px; margin-bottom: 40px;">
+
+    <div class="chart-container">
+      <h3>Side-by-Side Pill Charts (Full Demo)</h3>
+      <p>Demonstrating pill charts with different configurations, one loaded from JSON.</p>
+      <div class="pill-chart-row">
+        <div class="pill-chart-container">
+          <h4>Pill Chart 1 (from JSON)</h4>
+          <canvas id="pillChartFullDemo1" width="200" height="120"></canvas>
+        </div>
+        <div class="pill-chart-container">
+          <h4>Pill Chart 2 (JS Config)</h4>
+          <canvas id="pillChartFullDemo2" width="200" height="120"></canvas>
+        </div>
+      </div>
     </div>
 
     <hr style="margin-top: 40px; margin-bottom: 40px;">
@@ -918,6 +963,65 @@
             });
 
             // Percentage Chart (Direct Values) Demo
+
+            // Side-by-side Pill Charts for Full Demo
+            PureChart.fromJSON('pillChartFullDemo1', 'pill_chart_example.json')
+                .then(chart => {
+                    if (chart && chart.isValid) { // Check isValid
+                        console.log('Pill Chart 1 (Full Demo) loaded successfully from JSON.');
+                    } else {
+                        console.error('Failed to load or invalid Pill Chart 1 (Full Demo) from JSON.');
+                        const canvas = document.getElementById('pillChartFullDemo1');
+                        if (canvas && canvas.getContext) {
+                            const ctx = canvas.getContext('2d');
+                            ctx.clearRect(0,0,canvas.width,canvas.height);
+                            ctx.font = '10px Arial'; ctx.fillStyle = 'red'; ctx.textAlign = 'center';
+                            ctx.fillText('Error loading from JSON or invalid.', canvas.width/2, canvas.height/2);
+                        }
+                    }
+                })
+                .catch(error => {
+                    console.error('Error loading Pill Chart 1 (Full Demo) from JSON:', error);
+                     const canvas = document.getElementById('pillChartFullDemo1');
+                        if (canvas && canvas.getContext) {
+                            const ctx = canvas.getContext('2d');
+                            ctx.clearRect(0,0,canvas.width,canvas.height);
+                            ctx.font = '10px Arial'; ctx.fillStyle = 'red'; ctx.textAlign = 'center';
+                            ctx.fillText('Catch: Error loading from JSON.', canvas.width/2, canvas.height/2);
+                        }
+                });
+
+            new PureChart('pillChartFullDemo2', {
+                type: 'pill',
+                data: {},
+                options: {
+                    pill: {
+                        min: 10, max: 90, value: 50,
+                        zoneMin: 25, zoneMax: 75,
+                        borderRadius: 5,
+                        pillHeight: 20,
+                        colors: {
+                            mainBackground: '#f8f9fa', // Lighter gray
+                            zoneBackground: '#e9ecef', // Slightly darker gray for zone
+                            cursor: '#007bff', // Blue cursor
+                            text: '#212529',
+                            minMaxText: '#495057',
+                            valueText: '#000'
+                        },
+                        zoneOverflowAmount: 5,
+                        showMinMaxLabels: true, // Show min/max like 10 and 90
+                        showValueLabel: true, // Show the current value (50)
+                        valueLabelPosition: 'above', // Show 50 above
+                        showZoneMinMaxLabels: true, // Show zone labels like 25 and 75
+                        zoneLabelPosition: 'below', // Show 25 and 75 below the pill zone
+                        zoneLabelFont: '9px sans-serif',
+                        zoneLabelColor: '#343a40',
+                        zoneLabelOffset: 3,
+                        zoneLabelBackgroundColor: 'rgba(255,255,255,0.5)'
+                    }
+                }
+            });
+
             const directPercentageChartConfig = {
                 type: "percentageDistribution",
                 data: {

--- a/PureChart/pill_chart_example.json
+++ b/PureChart/pill_chart_example.json
@@ -2,38 +2,38 @@
   "type": "pill",
   "data": {},
   "options": {
-    "title": {
-      "display": false,
-      "text": "Pill Chart Example: Task Completion",
-      "font": "16px Arial bold",
-      "color": "#333"
-    },
-    "width": 600,
-    "height": 120,
-    "padding": { "top": 10, "right": 10, "bottom": 40, "left": 10 },
     "pill": {
       "min": 0,
-      "max": 100,
-      "zoneMin": 60,
-      "zoneMax": 90,
+      "max": 150,
       "value": 75,
-      "borderRadius": 10,
-      "pillHeight": 40,
-      "pillBorderWidth": 2,
-      "fillLightenPercent": 70,
+      "zoneMin": 30,
+      "zoneMax": 120,
+      "borderRadius": 8,
+      "pillHeight": 25,
       "colors": {
-        "mainBackground": "#000000",
-        "zoneBackground": "#50E3C2",
-        "cursor": "#D0021B",
-        "minMaxText": "#4A4A4A",
-        "valueText": "#2F2F2F"
+        "mainBackground": "#DDDDDD",
+        "zoneBackground": "#B0B0B0",
+        "cursor": "#FF3300",
+        "text": "#101010",
+        "minMaxText": "#444444",
+        "valueText": "#000000"
       },
-      "cursorThickness": 4,
-      "cursorLengthExtension": 8,
+      "cursorThickness": 3,
+      "cursorLengthExtension": 6,
       "showMinMaxLabels": true,
       "showValueLabel": true,
       "valueLabelPosition": "below",
-      "labelFont": "12px Arial"
+      "labelFont": "12px Courier New",
+      "pillBorderWidth": 2,
+      "fillLightenPercent": 60,
+      "zoneOverflowAmount": 7,
+      "showZoneMinMaxLabels": true,
+      "zoneLabelFont": "11px Verdana",
+      "zoneLabelColor": "#FFFFFF",
+      "zoneLabelOffset": 5,
+      "zoneLabelBackgroundPadding": 3,
+      "zoneLabelBackgroundColor": "rgba(0, 0, 0, 0.6)",
+      "zoneLabelPosition": "on"
     }
   }
 }


### PR DESCRIPTION
This commit introduces the following improvements to PureChart's demonstration and examples:

1.  **Side-by-Side Pill Chart Demo:**
    - I modified `PureChart/demo.html` to display two pill charts side-by-side. Each chart has a maximum width of 200px and showcases different `zoneLabelPosition` configurations ('above' and 'on'), providing a clearer comparison of this feature.
    - I added a similar side-by-side pill chart section to `PureChart/demo_full.html`.

2.  **Comprehensive Pill Chart JSON Example:**
    - I updated `PureChart/pill_chart_example.json` to include all available pill-specific configuration options.
    - Each option is presented with an illustrative example value, making the JSON file a more comprehensive guide for you when looking to configure pill charts.

3.  **JSON Loading in Full Demo:**
    - One of the new side-by-side pill charts in `PureChart/demo_full.html` now loads its configuration directly from the updated `PureChart/pill_chart_example.json` using `PureChart.fromJSON()`. This demonstrates the capability of loading detailed configurations from external JSON files.

These changes improve the clarity and utility of the pill chart demos and provide a more robust example configuration in JSON format.