### PR TITLE
fix: Correct JavaScript SyntaxError in index.html

### DIFF
--- a/Mindmap/index.html
+++ b/Mindmap/index.html
@@ -167,7 +167,9 @@
                     return;
                 }
                 const nodeText = mindmap.getNodeById(selectedNodeId).text;
-                const confirmRemove = confirm(\`Are you sure you want to remove node "\${nodeText}" and all its children?\`);
+                // Corrected line below:
+                const confirmMessage = "Are you sure you want to remove node \"" + nodeText + "\" and all its children?";
+                const confirmRemove = confirm(confirmMessage);
                 if (confirmRemove) {
                     const parentOfSelected = mindmap.getNodeById(selectedNodeId).parentId;
                     mindmap.removeNode(selectedNodeId);


### PR DESCRIPTION
Resolves an "Uncaught SyntaxError: invalid escape sequence" in Mindmap/index.html. The error was caused by a template literal in the confirm() dialog message for node removal.

The problematic template literal has been replaced with standard string concatenation to construct the confirmation message, ensuring no invalid escape sequences are present. This allows the node removal confirmation dialog and other JavaScript functionalities on the page to work correctly.