### PR TITLE
feat: Add font and position options for pill chart main labels

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -192,7 +192,9 @@ class PureChart {
                     showMinMaxLabels: true,
                     showValueLabel: true,
                     valueLabelPosition: 'below', // 'above', 'below', 'inside'
-                    labelFont: '10px Arial',
+                    labelFont: '10px Arial', // General font for Min/Max/Value labels if mainLabelFont is not specified
+                    mainLabelFont: '11px Arial', // Specific font for Min, Max, and Value labels
+                    minMaxLabelPosition: 'ends', // Options: 'ends', 'aboveEnds', 'belowEnds'
                     pillBorderWidth: 1,
                     fillLightenPercent: 70,
                     zoneOverflowAmount: 5, // Default overflow amount in pixels
@@ -2959,27 +2961,56 @@ class PureChart {
 
         // Draw Min/Max Labels
         if (pillOptions.showMinMaxLabels) {
-            this.ctx.font = pillOptions.labelFont;
+            this.ctx.font = pillOptions.mainLabelFont || pillOptions.labelFont; // Prioritize mainLabelFont
             this.ctx.fillStyle = pillOptions.colors.minMaxText;
-            const labelY = pillY + pillOptions.pillHeight / 2;
 
-            // Min Label
-            this.ctx.textAlign = 'left';
-            this.ctx.textBaseline = 'middle';
-            // Small padding from the edge, ensure it's within the component bounds
-            const minLabelX = Math.max(drawArea.x + 2, drawArea.x + pillOptions.borderRadius / 2 + 2) ;
-            this.ctx.fillText(String(pillOptions.min), minLabelX, labelY);
+            const minMaxLabelPosition = pillOptions.minMaxLabelPosition;
+            const originalLabelY = pillY + pillOptions.pillHeight / 2;
+            let minLabelX, maxLabelX, currentLabelY, minTextAlign, maxTextAlign, currentTextBaseline;
+            const labelOffset = pillOptions.zoneLabelOffset || 5; // Using zoneLabelOffset as a generic offset
 
-            // Max Label
-            this.ctx.textAlign = 'right';
-            this.ctx.textBaseline = 'middle';
-            const maxLabelX = Math.min(drawArea.x + drawArea.width - 2, drawArea.x + drawArea.width - pillOptions.borderRadius / 2 - 2);
-            this.ctx.fillText(String(pillOptions.max), maxLabelX, labelY);
+            switch(minMaxLabelPosition) {
+                case 'aboveEnds':
+                    currentLabelY = pillY - labelOffset;
+                    currentTextBaseline = 'bottom';
+                    minTextAlign = 'left';
+                    maxTextAlign = 'right';
+                    minLabelX = drawArea.x + (pillOptions.borderRadius / 2 || 0) + 2;
+                    maxLabelX = drawArea.x + drawArea.width - (pillOptions.borderRadius / 2 || 0) - 2;
+                    break;
+                case 'belowEnds':
+                    currentLabelY = pillY + pillOptions.pillHeight + labelOffset;
+                    currentTextBaseline = 'top';
+                    minTextAlign = 'left';
+                    maxTextAlign = 'right';
+                    minLabelX = drawArea.x + (pillOptions.borderRadius / 2 || 0) + 2;
+                    maxLabelX = drawArea.x + drawArea.width - (pillOptions.borderRadius / 2 || 0) - 2;
+                    break;
+                case 'ends':
+                default:
+                    currentLabelY = originalLabelY;
+                    currentTextBaseline = 'middle';
+                    minTextAlign = 'left';
+                    maxTextAlign = 'right';
+                    minLabelX = Math.max(drawArea.x + 2, drawArea.x + pillOptions.borderRadius / 2 + 2);
+                    maxLabelX = Math.min(drawArea.x + drawArea.width - 2, drawArea.x + drawArea.width - pillOptions.borderRadius / 2 - 2);
+                    break;
+            }
+
+            // Drawing Min Label
+            this.ctx.textAlign = minTextAlign;
+            this.ctx.textBaseline = currentTextBaseline;
+            this.ctx.fillText(String(pillOptions.min), minLabelX, currentLabelY);
+
+            // Drawing Max Label
+            this.ctx.textAlign = maxTextAlign;
+            // this.ctx.textBaseline = currentTextBaseline; // Already set
+            this.ctx.fillText(String(pillOptions.max), maxLabelX, currentLabelY);
         }
 
         // Draw Value Label
         if (pillOptions.showValueLabel) {
-            this.ctx.font = pillOptions.labelFont; // Could be a different font, e.g., pillOptions.valueLabelFont
+            this.ctx.font = pillOptions.mainLabelFont || pillOptions.labelFont; // Prioritize mainLabelFont
             this.ctx.fillStyle = pillOptions.colors.valueText;
             this.ctx.textAlign = 'center';
 

--- a/PureChart/README.md
+++ b/PureChart/README.md
@@ -60,7 +60,12 @@ The Pill Chart is a horizontal chart designed to display a single value against 
 *   `showMinMaxLabels` (boolean): Whether to display the min and max value labels. Default: `true`.
 *   `showValueLabel` (boolean): Whether to display the current value label. Default: `true`.
 *   `valueLabelPosition` (string): Position of the value label ('above', 'below', 'inside'). Default: `'below'`.
-*   `labelFont` (string): Font style for the labels. Default: `'10px Arial'`.
+*   `labelFont` (string): Font style for the labels. Default: `'10px Arial'`. (Used for Min/Max/Value labels if `mainLabelFont` is not specified).
+*   `mainLabelFont` (string): Specific font for the main Min, Max, and Value labels of the pill chart. If not provided, `labelFont` is used. Example default: `'11px Arial'`.
+*   `minMaxLabelPosition` (string): Position of the main Min and Max labels. Default: `'ends'`.
+    *   `'ends'`: Labels are drawn inside, near the ends of the pill bar.
+    *   `'aboveEnds'`: Labels are drawn above the pill bar, aligned with its ends.
+    *   `'belowEnds'`: Labels are drawn below the pill bar, aligned with its ends.
 *   `zoneOverflowAmount` (number): The amount in pixels by which the highlighted zone (`zoneMin` to `zoneMax`) will extend vertically (both top and bottom) beyond the main `pillHeight`. This creates a visual effect where the zone appears taller than the pill bar. Default: `5`.
 
     *Example of `zoneOverflowAmount` in action:*
@@ -83,6 +88,22 @@ The Pill Chart is a horizontal chart designed to display a single value against 
             zoneLabelColor: 'blue',
             zoneLabelOffset: 8
         }
+    }
+    ```
+
+    *Example: Customizing Main Min/Max/Value Label Font and Min/Max Position*
+    ```javascript
+    options: {
+      pill: {
+        // ... other options
+        showMinMaxLabels: true, // Ensure Min/Max labels are shown
+        mainLabelFont: '12px "Courier New", monospace',
+        minMaxLabelPosition: 'aboveEnds', // Position Min/Max labels above the pill ends
+
+        showValueLabel: true, // Ensure Value label is shown
+        valueLabelPosition: 'below', // Value label will also use mainLabelFont
+        // ... other pill options
+      }
     }
     ```
 

--- a/PureChart/demo.html
+++ b/PureChart/demo.html
@@ -57,16 +57,16 @@
     </div>
 
     <!-- New Pill Chart with Zone Overflow and Zone Labels Demo -->
-    <div class="chart-container"> <!-- Keep original h2 and p for the section -->
-        <h2>Example 4: Side-by-Side Pill Charts with Zone Labels</h2>
-        <p>These pill charts demonstrate different <code>zoneLabelPosition</code> options ('above' vs 'on') and custom styling for zone labels. They are displayed side-by-side using flexbox.</p>
+    <div class="chart-container"> <!-- Keep original h2 for the section -->
+        <h2>Example 4: Side-by-Side Pill Charts - Main & Zone Labels</h2>
+        <p>These pill charts demonstrate <code>zoneLabelPosition</code>, <code>mainLabelFont</code>, and <code>minMaxLabelPosition</code> options, showcasing various label configurations. They are displayed side-by-side.</p>
         <div class="pill-chart-row">
             <div class="pill-chart-container">
-                <h4>Pill Chart 1 (Labels Above)</h4>
+                <h4>Pill 1: Custom Font, Min/Max Below</h4>
                 <canvas id="pillChartDemo1" width="200" height="120"></canvas>
             </div>
             <div class="pill-chart-container">
-                <h4>Pill Chart 2 (Labels On Zone)</h4>
+                <h4>Pill 2: Default Font, Min/Max Above</h4>
                 <canvas id="pillChartDemo2" width="200" height="120"></canvas>
             </div>
         </div>
@@ -410,12 +410,11 @@
             };
             new PureChart('contourChartCanvas', contourChartConfig);
 
-            // Pill Chart Demo 1: Labels Above
+            // Pill Chart Demo 1: Custom Font, Min/Max Below
             const pillConfig1 = {
                 type: 'pill',
                 data: {},
                 options: {
-                    // No main title for individual small charts, title is in H4
                     pill: {
                         min: 0,
                         max: 100,
@@ -425,6 +424,7 @@
                         pillHeight: 20,
                         borderRadius: 6,
                         zoneOverflowAmount: 8,
+                        // Zone Label options (from previous setup)
                         showZoneMinMaxLabels: true,
                         zoneLabelPosition: 'above',
                         zoneLabelFont: '10px Arial',
@@ -432,18 +432,25 @@
                         zoneLabelOffset: 5,
                         zoneLabelBackgroundColor: 'rgba(230,230,230,0.7)',
                         zoneLabelBackgroundPadding: 2,
+                        // New Main Label options for Min/Max/Value
+                        showMinMaxLabels: true, // Ensure Min/Max labels are shown
+                        mainLabelFont: '12px "Lucida Console", Monaco, monospace',
+                        minMaxLabelPosition: 'belowEnds', // Demonstrate 'belowEnds'
+                        showValueLabel: true, // Ensure value label is shown (will use mainLabelFont)
+                        valueLabelPosition: 'above', // Keep value label above for this example
                         colors: {
                             mainBackground: '#e9ecef',
-                            zoneBackground: '#cfe2ff', // Light blue
+                            zoneBackground: '#cfe2ff',
                             cursor: '#0d6efd',
-                            valueText: '#000'
+                            minMaxText: '#003366', // Darker blue for Min/Max
+                            valueText: '#0066cc'   // Medium blue for Value
                         }
                     }
                 }
             };
             new PureChart('pillChartDemo1', pillConfig1);
 
-            // Pill Chart Demo 2: Labels On Zone
+            // Pill Chart Demo 2: Default Font, Min/Max Above
             const pillConfig2 = {
                 type: 'pill',
                 data: {},
@@ -457,18 +464,27 @@
                         pillHeight: 20,
                         borderRadius: 6,
                         zoneOverflowAmount: 5,
+                        // Zone Label options (from previous setup)
                         showZoneMinMaxLabels: true,
                         zoneLabelPosition: 'on',
                         zoneLabelFont: '9px Arial bold',
-                        zoneLabelColor: '#ffffff', // White text for on-zone
-                        zoneLabelOffset: 4, // Small offset for 'on'
-                        zoneLabelBackgroundColor: 'rgba(0,0,0,0.3)', // Slightly transparent black bg for contrast
+                        zoneLabelColor: '#ffffff',
+                        zoneLabelOffset: 4,
+                        zoneLabelBackgroundColor: 'rgba(0,0,0,0.3)',
                         zoneLabelBackgroundPadding: 1,
+                        // New Main Label options for Min/Max/Value
+                        showMinMaxLabels: true, // Ensure Min/Max labels are shown
+                        minMaxLabelPosition: 'aboveEnds', // Demonstrate 'aboveEnds'
+                        // mainLabelFont is not set here, so it will use fallback (labelFont or default mainLabelFont)
+                        labelFont: '10px Verdana, sans-serif', // Explicitly set labelFont to show fallback mechanism
+                        showValueLabel: true, // Ensure value label is shown
+                        valueLabelPosition: 'below', // Value label will use labelFont or default mainLabelFont
                         colors: {
                             mainBackground: '#e9ecef',
-                            zoneBackground: '#20c997', // Teal/Green
-                            cursor: '#6f42c1', // Purple
-                            valueText: '#000'
+                            zoneBackground: '#20c997',
+                            cursor: '#6f42c1',
+                            minMaxText: '#555',    // Standard gray for Min/Max
+                            valueText: '#222'     // Dark gray for Value
                         }
                     }
                 }

--- a/PureChart/pill_chart_example.json
+++ b/PureChart/pill_chart_example.json
@@ -24,6 +24,8 @@
       "showValueLabel": true,
       "valueLabelPosition": "below",
       "labelFont": "12px Courier New",
+      "mainLabelFont": "bold 12px Arial, sans-serif",
+      "minMaxLabelPosition": "aboveEnds",
       "pillBorderWidth": 2,
       "fillLightenPercent": 60,
       "zoneOverflowAmount": 7,


### PR DESCRIPTION
This commit introduces further customization options for the main Min, Max, and Value labels on PureChart pill charts:

1.  **Main Label Font (`mainLabelFont`):**
    - Added a new `options.pill.mainLabelFont` configuration.
    - This option allows you to specify a distinct font for the primary Min, Max, and Value labels, overriding the general `options.pill.labelFont` for these specific labels.
    - If `mainLabelFont` is not provided, the behavior falls back to `labelFont`, and then to the chart's global default font.

2.  **Min/Max Label Position (`minMaxLabelPosition`):**
    - Added a new `options.pill.minMaxLabelPosition` configuration.
    - This option controls the placement of the main Min and Max labels. Possible values are:
        - `'ends'` (default): Labels are drawn inside, near the ends of the pill bar.
        - `'aboveEnds'`: Labels are drawn above the pill bar, aligned with its ends. - `'belowEnds'`: Labels are drawn below the pill bar, aligned with its ends.
    - The `_drawPillChart` method in `PureChart.js` has been updated to implement this new positioning logic.

3.  **Documentation Updates:**
    - `PureChart/README.md` has been updated to document these new `mainLabelFont` and `minMaxLabelPosition` options, including their purpose, possible values, and usage examples.

4.  **Demo Enhancements:**
    - `PureChart/demo.html` has been updated to showcase the new font and positioning options in its side-by-side pill chart examples.
    - `PureChart/pill_chart_example.json` has been updated to include `mainLabelFont` and `minMaxLabelPosition` with illustrative example values, making it a more comprehensive configuration guide.

These enhancements provide you with greater control over the appearance and layout of key textual information on pill charts.