### PR TITLE
feat: Implement advanced styling for nodes and connectors

### DIFF
--- a/Mindmap/README.md
+++ b/Mindmap/README.md
@@ -2,16 +2,30 @@
 
 A JavaScript library for creating and managing interactive mind maps.
 
-## Current Features (v0.1.0 - Initial Release)
+## Current Features (v0.2.0 - Styling Update)
 
 *   **Node Management:**
-    *   Create a central topic: `mindmap.addCentralTopic({ text: 'My Topic' })`
-    *   Create child nodes: `mindmap.createNode(parentNodeId, { text: 'Child Idea' })`
+    *   Create a central topic: `mindmap.addCentralTopic({ text: 'My Topic', style: {...} })`
+    *   Create child nodes: `mindmap.createNode(parentNodeId, { text: 'Child Idea', style: {...} })\`
     *   Get node data: `mindmap.getNodeById(nodeId)`
-    *   Update node text: `mindmap.updateNode(nodeId, { text: 'New Text' })` (also via double-click on a node)
+    *   Update node text and style: `mindmap.updateNode(nodeId, { text: 'New Text', style: {...} })` (text also via double-click)
     *   Remove nodes (and their children recursively): `mindmap.removeNode(nodeId)`
+*   **Node Styling (via `style` object on nodes):**
+    *   `backgroundColor`: Background color (e.g., `'#RRGGBB'`, `'white'`). Default: `'#f8f9fa'`.
+    *   `textColor`: Text color. Default: `'#212529'`.
+    *   `borderColor`: Border color. Default: `'#ced4da'`.
+    *   `borderWidth`: Border width (e.g., `'2px'`, `2`). Default: `'2px'`.
+    *   `borderStyle`: Border style (e.g., `'solid'`, `'dashed'`). Default: `'solid'`.
+    *   `fontSize`: Font size (e.g., `'1.2em'`, `'16px'`). Default: `'1em'`.
+    *   `fontWeight`: Font weight (e.g., `'bold'`, `'normal'`). Default: `'normal'`.
+    *   `fontFamily`: Font family (e.g., `'Arial, sans-serif'`). Default: `'sans-serif'`.
+    *   `borderRadius`: Border radius for rounded corners (e.g., `'10px'`, `10`). Default: `'6px'`.
+    *   `padding`: Padding inside the node (e.g., `'10px 15px'`). Default: `'12px 18px'`.
+*   **Connector Styling (via `options` in `Mindmap` constructor):**
+    *   `connectorColor`: Color of the connector lines. Default: `'black'`.
+    *   `connectorWidth`: Width/thickness of connector lines in pixels. Default: `1`.
 *   **Basic Rendering:**
-    *   Nodes are rendered as simple divs.
+    *   Nodes are rendered as styled divs.
     *   Connectors (straight lines) are drawn between parent and child nodes.
 
 ## Setup
@@ -31,53 +45,86 @@ A JavaScript library for creating and managing interactive mind maps.
 4.  Initialize the library in a script:
     ```javascript
     document.addEventListener('DOMContentLoaded', () => {
-        const mindmap = new Mindmap('myMindmapContainer'); // Use the ID of your container
+        // Example: Initialize with custom connector styles
+        const mindmap = new Mindmap('myMindmapContainer', {
+            connectorColor: 'gray',
+            connectorWidth: 2
+        });
 
-        // Add a central topic
-        const central = mindmap.addCentralTopic({ text: 'Main Idea' });
+        // Add a central topic with custom style
+        const central = mindmap.addCentralTopic({
+            text: 'Main Idea (Styled)',
+            style: {
+                backgroundColor: '#007bff',
+                textColor: 'white',
+                borderColor: '#0056b3',
+                borderWidth: '3px', // or just 3
+                borderRadius: '10px', // or just 10
+                fontSize: '1.2em',
+                padding: '15px 20px',
+                fontWeight: 'bold'
+            }
+        });
 
-        // Add child nodes
+        // Add child nodes with different styles
         if (central) {
-            const child1 = mindmap.createNode(central.id, { text: 'Concept 1' });
-            const child2 = mindmap.createNode(central.id, { text: 'Concept 2 (Dbl-Click Me!)' });
+            const child1Style = {
+                backgroundColor: '#28a745',
+                textColor: 'white',
+                borderRadius: '50px',
+                borderColor: 'darkgreen',
+                fontFamily: 'Courier New, monospace'
+            };
+            const child1 = mindmap.createNode(central.id, { text: 'Concept 1 (Green & Rounded)', style: child1Style });
+
+            const child2Style = {
+                backgroundColor: '#ffc107',
+                textColor: '#333',
+                borderColor: '#e0a800',
+                borderStyle: 'dashed',
+                borderWidth: '2px'
+            };
+            const child2 = mindmap.createNode(central.id, { text: 'Concept 2 (Yellow & Dashed)', style: child2Style });
 
             if (child1) {
-                mindmap.createNode(child1.id, { text: 'Sub-Concept 1.1' });
+                mindmap.createNode(child1.id, { text: 'Sub-Concept 1.1 (Default Style)' });
             }
-            if (child2) {
-                const child2_1 = mindmap.createNode(child2.id, { text: 'Sub-Concept 2.1' });
-                if (child2_1) {
-                     mindmap.createNode(child2_1.id, { text: 'Sub-Sub-Concept 2.1.1 (Dbl-Click Me!)' });
-                }
-            }
-            mindmap.createNode(central.id, { text: 'Concept 3' });
         }
 
-        // Example of using other functions:
-        // To remove a node (e.g., child2 and its children):
+        // Example of updating a node's style programmatically:
         // setTimeout(() => {
-        // if (child2) mindmap.removeNode(child2.id);
+        //   if (child1) {
+        //     mindmap.updateNode(child1.id, {
+        //       style: { backgroundColor: '#dc3545', textColor: 'white', borderColor: 'darkred' }
+        //     });
+        //   }
         // }, 5000);
 
-        // To update a node programmatically:
+        // Example of removing a node:
         // setTimeout(() => {
-        // if (child1) mindmap.updateNode(child1.id, { text: 'Updated Concept 1' });
-        // }, 3000);
+        //   if (child2) mindmap.removeNode(child2.id);
+        // }, 7000);
     });
     ```
 
 ## How to Use `index.html` Demo
 
 *   Open `Mindmap/index.html` in your browser.
-*   A sample mind map will be created.
-*   **Double-click** on any node to edit its text.
-*   The demo script in `mindmap.js` currently removes some nodes automatically after a few seconds to demonstrate the `removeNode` functionality. You can comment this out in `mindmap.js` if you want to interact with the map longer.
+*   The demo page starts with an empty mind map.
+*   Use the controls provided to:
+    *   Set node text and various style properties (background color, text color, border color, border radius) before adding a new node.
+    *   Add a central topic or child nodes.
+    *   Select a node to see its current style properties reflected in the input fields.
+    *   Update the style of the selected node.
+    *   Set connector color and width, then click "Re-initialize Map with New Connector Styles" to clear the map and apply these styles to new connectors (for existing connectors to change, the map would need a full redraw or re-add nodes).
+*   **Double-click** on any node to edit its text directly.
 
 ## Future Development
 
-This is a very basic version. Future enhancements will include:
-*   Advanced styling for nodes and connectors.
+This is a basic version. Future enhancements will include:
+*   More advanced connector styling (e.g., dashed, dotted lines directly via options).
+*   More shapes for nodes.
 *   Drag-and-drop node manipulation.
-*   Zoom and pan.
-*   Import/Export features.
+*   Zoom and pan functionality.
+*   Import/Export features (e.g., JSON).
 *   And much more from the initial specification!

--- a/Mindmap/index.html
+++ b/Mindmap/index.html
@@ -3,94 +3,105 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mindmap JS Library - Interactive Demo</title>
+    <title>Mindmap JS Library - Advanced Demo</title>
     <link rel="stylesheet" href="mindmap.css">
     <style>
-        body { font-family: sans-serif; margin: 20px; background-color: #f9f9f9; }
-        h1 { text-align: center; color: #333; }
-        #controls { margin-bottom: 20px; padding: 15px; background-color: #e9ecef; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 10px;}
-        #controls button, #controls input[type="text"] { padding: 10px 15px; border-radius: 5px; border: 1px solid #ced4da; font-size: 1em; }
-        #controls input[type="text"] { min-width: 150px; }
-        #controls button { background-color: #007bff; color: white; cursor: pointer; transition: background-color 0.2s ease; }
-        #controls button:hover { background-color: #0056b3; }
-        #controls button:disabled { background-color: #c0c0c0; cursor: not-allowed; }
-        #selectedNodeInfo { margin-top:10px; padding: 10px; background-color: #fff; border: 1px solid #ddd; border-radius: 5px; font-size: 0.9em; }
-        #selectedNodeIdDisplay { font-weight: bold; color: #007bff; }
+        body { font-family: Arial, sans-serif; margin: 15px; background-color: #f4f7f6; color: #333; }
+        h1 { text-align: center; color: #2c3e50; margin-bottom: 20px;}
+        #controlsContainer { display: flex; justify-content: space-around; margin-bottom: 20px; padding: 15px; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .control-group { padding: 10px; border: 1px solid #e0e0e0; border-radius: 6px; }
+        .control-group h4 { margin-top: 0; margin-bottom: 10px; color: #3498db; }
+        #controls button, #controls input[type="text"], #controls input[type="color"], #controls input[type="number"] {
+            padding: 9px 14px; margin: 5px 2px; border-radius: 5px; border: 1px solid #ccc;
+            font-size: 0.95em; box-sizing: border-box;
+        }
+        #controls input[type="text"], #controls input[type="color"], #controls input[type="number"] { width: calc(100% - 10px); }
+        #controls button { background-color: #3498db; color: white; cursor: pointer; transition: background-color 0.2s; }
+        #controls button:hover { background-color: #2980b9; }
+        #controls button:disabled { background-color: #bdc3c7; cursor: not-allowed; }
+        #selectedNodeInfo { margin-top:10px; padding: 8px; background-color: #ecf0f1; border: 1px solid #ddd; border-radius: 5px; font-size: 0.9em; text-align: center; }
+        #selectedNodeIdDisplay { font-weight: bold; color: #2980b9; }
         #mindmapContainer {
-            width: 95%;
+            width: 100%;
             max-width: 1200px;
-            height: 700px;
-            border: 2px solid #007bff;
+            height: 650px;
+            border: 2px solid #3498db;
             border-radius: 8px;
             position: relative;
             overflow: auto;
             margin: 20px auto;
             background-color: #ffffff;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
         }
-        /* General node styling (can be overridden by specific node styles from library) */
-        .mindmap-node {
-            padding: 12px 18px;
-            border: 2px solid #ced4da; /* Default border */
-            background-color: #f8f9fa;
-            border-radius: 6px;
-            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-            cursor: default;
-            transition: border-color 0.3s ease, box-shadow 0.3s ease;
+        .mindmap-node { /* Base style, library overrides take precedence for specifics if defined in node.style */
+            padding: 10px 15px; border: 2px solid #ddd; background-color: #fff; border-radius: 5px;
+            box-shadow: 1px 1px 3px rgba(0,0,0,0.1); cursor: default;
         }
-        .mindmap-node:hover {
-            box-shadow: 0 4px 10px rgba(0,0,0,0.2);
-        }
+         .control-group input[type="color"] { height: 40px; padding: 5px; } /* Make color pickers a bit taller */
     </style>
 </head>
 <body>
-    <h1>Mindmap JS Library - Interactive Demo</h1>
+    <h1>Mindmap JS Library - Advanced Styling Demo</h1>
 
-    <div id="controls">
-        <input type="text" id="nodeText" placeholder="Node Text" value="New Idea">
-        <button id="addRootBtn">Add Central Topic</button>
-        <button id="addChildBtn" disabled>Add Child to Selected</button>
-        <button id="removeNodeBtn" disabled>Remove Selected Node</button>
-        <div id="selectedNodeInfo">Selected Node ID: <span id="selectedNodeIdDisplay">None</span></div>
+    <div id="controlsContainer">
+        <div class="control-group" id="nodeControls">
+            <h4>Node Properties</h4>
+            <input type="text" id="nodeText" placeholder="Node Text" value="New Idea">
+            <input type="color" id="nodeBgColor" title="Node Background Color" value="#FFFFFF">
+            <input type="color" id="nodeTextColor" title="Node Text Color" value="#000000">
+            <input type="text" id="nodeBorderColor" placeholder="Border Color (e.g., #CCCCCC)" value="#CCCCCC">
+            <input type="text" id="nodeBorderRadius" placeholder="Border Radius (e.g., 5px)" value="6px">
+            <button id="addRootBtn">Add Central Topic</button>
+            <button id="addChildBtn" disabled>Add Child</button>
+            <button id="updateStyleBtn" disabled>Update Selected Style</button>
+            <button id="removeNodeBtn" disabled>Remove Selected</button>
+        </div>
+        <div class="control-group" id="connectorControls">
+            <h4>Connector Style (Applied on Init/Re-init)</h4>
+            <input type="color" id="connectorColorInput" title="Connector Color" value="#333333">
+            <input type="number" id="connectorWidthInput" title="Connector Width (px)" value="1" min="1" max="10">
+            <button id="reinitMapBtn">Re-initialize Map with New Connector Styles</button>
+        </div>
     </div>
+    <div id="selectedNodeInfo">Selected Node ID: <span id="selectedNodeIdDisplay">None</span></div>
     <p style="text-align:center;">Click a node to select it. Double-click a node to edit its text.</p>
 
-
-    <div id="mindmapContainer">
-        <!-- The mind map will be rendered here -->
-    </div>
+    <div id="mindmapContainer"></div>
 
     <script src="mindmap.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const mindmap = new Mindmap('mindmapContainer');
+            let mindmap; // Declare mindmap here to allow re-initialization
             let selectedNodeId = null;
+
             const selectedNodeIdDisplay = document.getElementById('selectedNodeIdDisplay');
             const nodeTextInput = document.getElementById('nodeText');
+            const nodeBgColorInput = document.getElementById('nodeBgColor');
+            const nodeTextColorInput = document.getElementById('nodeTextColor');
+            const nodeBorderColorInput = document.getElementById('nodeBorderColor');
+            const nodeBorderRadiusInput = document.getElementById('nodeBorderRadius');
+
+            const connectorColorInput = document.getElementById('connectorColorInput');
+            const connectorWidthInput = document.getElementById('connectorWidthInput');
+
             const addRootBtn = document.getElementById('addRootBtn');
             const addChildBtn = document.getElementById('addChildBtn');
+            const updateStyleBtn = document.getElementById('updateStyleBtn');
             const removeNodeBtn = document.getElementById('removeNodeBtn');
+            const reinitMapBtn = document.getElementById('reinitMapBtn');
 
             const updateButtonStates = () => {
-                if (mindmap.nodes.size === 0) {
-                    addRootBtn.disabled = false;
-                    addChildBtn.disabled = true;
-                    removeNodeBtn.disabled = true;
-                } else {
-                    addRootBtn.disabled = true; // Only one root for now
-                    if (selectedNodeId && mindmap.nodes.has(selectedNodeId)) {
-                        addChildBtn.disabled = false;
-                        removeNodeBtn.disabled = false;
-                    } else {
-                        addChildBtn.disabled = true;
-                        removeNodeBtn.disabled = true;
-                    }
-                }
+                const hasNodes = mindmap && mindmap.nodes.size > 0;
+                addRootBtn.disabled = hasNodes;
+                addChildBtn.disabled = !selectedNodeId || !hasNodes;
+                updateStyleBtn.disabled = !selectedNodeId || !hasNodes;
+                removeNodeBtn.disabled = !selectedNodeId || !hasNodes;
             };
 
             const deselectCurrentNode = () => {
                 if (selectedNodeId && document.getElementById(selectedNodeId)) {
-                    document.getElementById(selectedNodeId).style.borderColor = '#ced4da'; // Default border
+                    const currentElem = document.getElementById(selectedNodeId);
+                    if (currentElem) currentElem.style.borderColor = mindmap.nodes.get(selectedNodeId)?.style?.borderColor || '#ced4da'; // Revert to its own border or default
                 }
                 selectedNodeId = null;
                 selectedNodeIdDisplay.textContent = "None";
@@ -98,39 +109,52 @@
             };
 
             const selectNode = (nodeId, nodeElement) => {
-                deselectCurrentNode(); // Deselect previous
-                selectedNodeId = nodeId;
-                nodeElement.style.borderColor = '#007bff'; // Highlight selected node (blue)
-                selectedNodeIdDisplay.textContent = nodeId;
-                updateButtonStates();
-                console.log("Node selected:", nodeId);
-            };
-
-            // Override _renderNode to add selection logic and attach it to the instance
-            const originalRenderNode = mindmap._renderNode.bind(mindmap);
-            mindmap._renderNode = function(node) { // Use function keyword for 'this' to be mindmap instance
-                originalRenderNode(node); // Call original rendering
-                const nodeElement = document.getElementById(node.id);
-                if (nodeElement) {
-                    nodeElement.addEventListener('click', (event) => {
-                        event.stopPropagation(); // Prevent container click from firing
-                        selectNode(node.id, nodeElement);
-                    });
-                    // Double-click is already handled by the library's _renderNode
-                }
-            };
-
-            mindmap.container.addEventListener('click', () => { // Click on container to deselect
                 deselectCurrentNode();
+                selectedNodeId = nodeId;
+                if (nodeElement) nodeElement.style.borderColor = '#007bff'; // Highlight with a standard selection color
+                selectedNodeIdDisplay.textContent = nodeId;
+
+                // Populate style inputs with selected node's current style
+                const nodeData = mindmap.getNodeById(nodeId);
+                if (nodeData && nodeData.style) {
+                    nodeBgColorInput.value = nodeData.style.backgroundColor || '#FFFFFF';
+                    nodeTextColorInput.value = nodeData.style.textColor || '#000000';
+                    nodeBorderColorInput.value = nodeData.style.borderColor || '#CCCCCC';
+                    nodeBorderRadiusInput.value = nodeData.style.borderRadius || '6px';
+                }
+                updateButtonStates();
+            };
+
+            function setupMindmapInstance(options) {
+                mindmap = new Mindmap('mindmapContainer', options);
+                const originalRenderNode = mindmap._renderNode.bind(mindmap);
+                mindmap._renderNode = function(node) {
+                    originalRenderNode(node);
+                    const nodeElement = document.getElementById(node.id);
+                    if (nodeElement) {
+                        nodeElement.addEventListener('click', (event) => {
+                            event.stopPropagation();
+                            selectNode(node.id, nodeElement);
+                        });
+                    }
+                };
+                mindmap.container.addEventListener('click', deselectCurrentNode);
+            }
+
+            // Initial setup
+            setupMindmapInstance({
+                connectorColor: connectorColorInput.value,
+                connectorWidth: parseInt(connectorWidthInput.value, 10)
             });
+            updateButtonStates();
 
             addRootBtn.addEventListener('click', () => {
                 if (mindmap.nodes.size === 0) {
-                    const text = nodeTextInput.value.trim() || 'Central Topic';
-                    const central = mindmap.addCentralTopic({ text: text, style: { backgroundColor: '#ffe0b2'} }); // Orange for central
-                    if (central) {
-                       // Selection is handled by the overridden _renderNode via its click listener
-                    }
+                    const style = {
+                        backgroundColor: nodeBgColorInput.value, textColor: nodeTextColorInput.value,
+                        borderColor: nodeBorderColorInput.value, borderRadius: nodeBorderRadiusInput.value
+                    };
+                    mindmap.addCentralTopic({ text: nodeTextInput.value.trim() || 'Central Topic', style: style });
                 } else {
                     alert("A central topic already exists.");
                 }
@@ -138,67 +162,56 @@
             });
 
             addChildBtn.addEventListener('click', () => {
-                if (!selectedNodeId) {
-                    alert("Please select a parent node first.");
-                    return;
-                }
-                if (!mindmap.nodes.has(selectedNodeId)) {
-                    alert("Selected parent node no longer exists. Please re-select.");
-                    deselectCurrentNode();
-                    return;
-                }
-                const text = nodeTextInput.value.trim() || 'New Child';
-                const randomColor = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
-                const child = mindmap.createNode(selectedNodeId, { text: text, style: { backgroundColor: randomColor } });
-                if (child) {
-                    // Selection will be handled by click if desired
-                }
+                if (!selectedNodeId) { alert("Please select a parent node first."); return; }
+                if (!mindmap.nodes.has(selectedNodeId)) { alert("Selected parent node no longer exists."); deselectCurrentNode(); return; }
+                const style = {
+                    backgroundColor: nodeBgColorInput.value, textColor: nodeTextColorInput.value,
+                    borderColor: nodeBorderColorInput.value, borderRadius: nodeBorderRadiusInput.value
+                };
+                mindmap.createNode(selectedNodeId, { text: nodeTextInput.value.trim() || 'New Child', style: style });
                 updateButtonStates();
+            });
+
+            updateStyleBtn.addEventListener('click', () => {
+                if (!selectedNodeId || !mindmap.nodes.has(selectedNodeId)) { alert('Please select a node to update.'); return; }
+                const styleToUpdate = {
+                    backgroundColor: nodeBgColorInput.value, textColor: nodeTextColorInput.value,
+                    borderColor: nodeBorderColorInput.value, borderRadius: nodeBorderRadiusInput.value
+                };
+                const filteredStyle = Object.fromEntries(Object.entries(styleToUpdate).filter(([_, v]) => v.trim() !== ''));
+                if (Object.keys(filteredStyle).length > 0) {
+                    mindmap.updateNode(selectedNodeId, { style: filteredStyle });
+                } else {
+                    alert('No new style values provided to update.');
+                }
             });
 
             removeNodeBtn.addEventListener('click', () => {
-                if (!selectedNodeId) {
-                    alert("Please select a node to remove.");
-                    return;
-                }
-                if (!mindmap.nodes.has(selectedNodeId)) {
-                    alert("Selected node no longer exists. Please re-select.");
-                    deselectCurrentNode();
-                    return;
-                }
+                if (!selectedNodeId) { alert("Please select a node to remove."); return; }
+                if (!mindmap.nodes.has(selectedNodeId)) { alert("Selected node no longer exists."); deselectCurrentNode(); return; }
                 const nodeText = mindmap.getNodeById(selectedNodeId).text;
-                // Corrected line below:
                 const confirmMessage = "Are you sure you want to remove node \"" + nodeText + "\" and all its children?";
-                const confirmRemove = confirm(confirmMessage);
-                if (confirmRemove) {
-                    const parentOfSelected = mindmap.getNodeById(selectedNodeId).parentId;
+                if (confirm(confirmMessage)) {
                     mindmap.removeNode(selectedNodeId);
-                    deselectCurrentNode(); // Deselects and updates buttons
-                    if (parentOfSelected && mindmap.nodes.has(parentOfSelected)) {
-                        // Optionally, re-select the parent after deleting a child
-                        // selectNode(parentOfSelected, document.getElementById(parentOfSelected));
-                    }
+                    deselectCurrentNode(); // Also updates button states
                 }
-                updateButtonStates();
             });
 
-            // Initial state for buttons
-            updateButtonStates();
+            reinitMapBtn.addEventListener('click', () => {
+                if (confirm('This will clear the current mind map and apply new connector styles. Are you sure?')) {
+                    Array.from(mindmap.nodes.keys()).forEach(nodeId => mindmap.removeNode(nodeId)); // Clear data
+                    mindmap.container.innerHTML = ''; // Clear DOM
 
-// --- Section de création de la carte d exemple commentée pour un démarrage à vide ---
-//             // Create a simple example map to start with
-//             const central = mindmap.addCentralTopic({ text: 'Interactive Mindmap (Click Me!)', style: { backgroundColor: '#ffe0b2'} });
-//             if (central) {
-//                 // Initial selection is done by clicking the node element after it's rendered
-//                 // We can simulate this or let the user click
-//                 // For now, let's not auto-select, to encourage first click.
-//                 const child1 = mindmap.createNode(central.id, { text: 'Idea A (Select Me)', style: { backgroundColor: '#cce5ff'} });
-//                 if (child1) {
-//                     mindmap.createNode(child1.id, { text: 'Sub-Idea A1', style: { backgroundColor: '#e0f7fa'} });
-//                 }
-//                 mindmap.createNode(central.id, { text: 'Idea B (Dbl-Click to Edit)', style: { backgroundColor: '#d1c4e9'} });
-//             }
-            console.log("Interactive demo initialized. Select nodes and use controls.");
+                    setupMindmapInstance({
+                        connectorColor: connectorColorInput.value,
+                        connectorWidth: parseInt(connectorWidthInput.value, 10)
+                    });
+                    deselectCurrentNode(); // Resets selection and button states
+                    alert('Map cleared. New connector styles will apply to subsequently added connectors.');
+                }
+            });
+
+            console.log("Interactive demo initialized. Add nodes and use controls to style them.");
         });
     </script>
 </body>


### PR DESCRIPTION
This commit introduces comprehensive styling capabilities for mind map nodes and connectors.

**Node Styling Enhancements (in mindmap.js):**
- `MindmapNode`'s `style` object can now process detailed properties:
  - `backgroundColor`, `textColor`, `borderColor`, `borderWidth`, `borderStyle`
  - `fontSize`, `fontWeight`, `fontFamily`, `borderRadius`, `padding`.
- `_renderNode` method applies these styles with sensible defaults.
- `updateNode` method allows for partial or full updates to a node's `style` object, reflecting changes in the DOM.

**Connector Styling (in mindmap.js):**
- The `Mindmap` constructor now accepts an `options` object:
  - `options.connectorColor` (default: 'black')
  - `options.connectorWidth` (default: 1 pixel)
- `_renderConnector` method uses these options to style the connector lines.

**Demo Page Enhancements (Mindmap/index.html):**
- Added UI controls (color pickers, text/number inputs) to dynamically set node styles (background, text, border color, border radius) before creation or for updating selected nodes.
- Added UI controls to set connector color and width for map re-initialization.
- Implemented "Update Selected Style" button to apply style changes to the selected node.
- Implemented "Re-initialize Map with New Connector Styles" button.
- Node style input fields now populate with the selected node's current styles.

**Documentation (README.md):**
- Updated "Current Features" to reflect new styling options (v0.2.0).
- Provided detailed examples of how to use the new style properties for nodes and connector options at initialization.
- Updated "How to Use index.html Demo" to describe new UI controls.

These changes provide significant flexibility in customizing the visual appearance of the mind maps.