### PR TITLE
feat(mindmap): Apply configured style to new nodes by default

### DIFF
--- a/Mindmap/mindmap.js
+++ b/Mindmap/mindmap.js
@@ -23,6 +23,7 @@ class Mindmap {
         }
         this.nodes = new Map(); // Stores MindmapNode objects, keyed by nodeId
         this.nodeCounter = 0; // Simple ID generator
+        this.currentNodeStyle = {}; // Style for the currently selected node
 
         // Default connector style options
         this.options = {
@@ -65,7 +66,13 @@ class Mindmap {
             x: parentPosition.x,
             y: parentPosition.y + 70 + (childrenCount * 60)
         };
-        const newNode = new MindmapNode(nodeId, nodeData.text, parentNodeId, [], newNodePosition, nodeData.style);
+
+        let styleForNewNode = nodeData.style;
+        if (!styleForNewNode || Object.keys(styleForNewNode).length === 0) {
+            styleForNewNode = { ...this.currentNodeStyle };
+        }
+
+        const newNode = new MindmapNode(nodeId, nodeData.text, parentNodeId, [], newNodePosition, styleForNewNode);
         this.nodes.set(nodeId, newNode);
         parentNode.children.push(nodeId);
         console.log('Node created:', newNode, 'as child of', parentNodeId);
@@ -215,6 +222,7 @@ class Mindmap {
         }
         if (updatedData.style) {
             nodeToUpdate.style = { ...nodeToUpdate.style, ...updatedData.style };
+            this.currentNodeStyle = { ...nodeToUpdate.style }; // Update currentNodeStyle
             console.log("Node style data updated:", nodeId, nodeToUpdate.style);
         }
 


### PR DESCRIPTION
New nodes created in the mindmap will now automatically inherit the last configured style.

Previously, new nodes were always created with a hardcoded default style, requiring you to manually update the style for each new node if you wanted a different appearance.

This change introduces a `currentNodeStyle` property in the `Mindmap` class. This property is updated whenever a node's style is modified via the `updateNode` method (which is used by the "update selected style" functionality). The `createNode` method has been updated to use this `currentNodeStyle` as the default for new nodes, unless a specific style is provided during node creation.