### PR TITLE
Docs: Update README and demos for axis display and zero trimming feat…

### DIFF
--- a/PureChart/README.md
+++ b/PureChart/README.md
@@ -16,7 +16,8 @@ PureChart.js is a lightweight charting library with no external dependencies, de
 
 ### Key Features & Recent Updates
 
-*   **Default Hidden Axes:** For a cleaner default look, X and Y axes are now hidden by default. They can be easily enabled via `options.xAxis.display = true` and `options.yAxes[].display = true`.
+*   **Default Axis Display for Bar/Line Charts:** For `bar` and `line` chart types, X and Y axes are now displayed by default if their `display` property is not specified. To hide them, explicitly set `options.xAxis.display = false` or `options.yAxes[].display = false`. For other chart types like `percentageDistribution` or `pill`, axes generally remain hidden by default unless configured otherwise.
+*   **Trim Leading/Trailing Zeroes:** New option `options.showLeadingTrailingZeroes` (default: `false`) for bar and line charts. When `false`, continuous zero values at the beginning or end of datasets (and their corresponding X-axis labels) are automatically hidden, adjusting the chart to the relevant data range.
 *   **Enhanced Pill Chart Styling:** The Pill Chart's `zoneMin` and `zoneMax` area can now visually overflow the main pill bar using the `options.pill.zoneOverflowAmount` setting.
 *   **Global Contour Mode:** A new `options.contourColor` can be set. If a color is provided, charts (bars, lines, points) will render with a fill matching the chart's background (from the active theme) and an outline in the specified contour color, offering a distinct visual style.
 *   **Responsive Autosizing:** Charts now automatically resize to fit their parent container by default (`options.autosize = true`).
@@ -145,30 +146,50 @@ The Pill Chart is a horizontal chart designed to display a single value against 
 
 PureChart offers a wide range of options to customize its appearance and behavior. These are passed in the `options` object during chart instantiation.
 
+*   **`showLeadingTrailingZeroes`**: (Boolean, default: `false`)
+    *   Applies to `bar` and `line` chart types.
+    *   If `false` (default), continuous zero values at the beginning and/or end of all datasets (and their corresponding X-axis labels) are automatically hidden. The chart effectively zooms into the range where non-zero data exists.
+    *   If `true`, all data points and labels are shown, regardless of leading/trailing zero values.
+    *   If all data points for all datasets are zero and this option is `false`, the chart will display a "No data to display" message.
+
+    Example:
+    ```javascript
+    options: {
+        showLeadingTrailingZeroes: false, // Default behavior, can be omitted
+        // ... other options
+    }
+    ```
+    To show all data including leading/trailing zeroes:
+    ```javascript
+    options: {
+        showLeadingTrailingZeroes: true,
+        // ... other options
+    }
+    ```
+
 #### Axes Configuration (X and Y)
 
-By default, both X and Y axes are now hidden to provide a cleaner initial chart appearance. To display them, you need to explicitly enable them in your chart configuration:
+For `bar` and `line` chart types, X and Y axes are now displayed by default. If you wish to hide them, you must explicitly set their `display` property to `false`.
 
-**Example: Displaying Axes**
+**Example: Hiding an Axis for a Bar Chart**
 ```javascript
 new PureChart('myChartCanvas', {
     type: 'bar',
     data: { /* ... */ },
     options: {
         xAxis: {
-            display: true, // Shows the X-axis
+            display: false, // Hides the X-axis
             title: 'Categories'
-            // ... other xAxis options
         },
         yAxes: [{
-            display: true, // Shows this Y-axis
+            // display: true, // This Y-axis would be shown by default
             title: 'Values'
-            // ... other yAxis options for the first (or only) Y-axis
         }]
         // ... other options
     }
 });
 ```
+For other chart types like `percentageDistribution` or `pill`, axes are generally not displayed by default and would require `display: true` to be shown if applicable to that chart type.
 
 #### X-Axis Label Display
 

--- a/PureChart/demo.html
+++ b/PureChart/demo.html
@@ -135,6 +135,9 @@
                         display: true,
                         position: 'top'
                     },
+                    // For bar/line charts, xAxis and yAxes will display by default
+                    // if their 'display' property is not specified.
+                    // Here, neither xAxis nor yAxis have 'display' set, so they will be visible.
                     yAxis: {
                         displayTitle: true,
                         title: 'Count / Percentage'
@@ -493,7 +496,7 @@
 
             // --- Test Cases for showLeadingTrailingZeroes ---
             const trimmingTestContainer = document.createElement('div');
-            trimmingTestContainer.innerHTML = '<h2>Zero Trimming Tests (showLeadingTrailingZeroes: default false)</h2>';
+            trimmingTestContainer.innerHTML = '<h2>Data Trimming: `showLeadingTrailingZeroes` (default: false)</h2>';
             document.body.appendChild(trimmingTestContainer);
 
             function addChartDiv(id, title) {

--- a/PureChart/demo_full.html
+++ b/PureChart/demo_full.html
@@ -519,8 +519,10 @@
                     theme: 'dark', 
                     title: { text: "Quarterly Product Performance (Dark Theme)" },
                     legend: { display: true, position: 'top' },
-                    xAxis: { display: true, title: "Quarters", displayTitle: true },
-                    yAxes: [{ display: true, title: "Units Sold", displayTitle: true }],
+                    // For bar/line charts, axes display by default if not specified.
+                    // xAxis.display and yAxes[0].display are not set here, so they will be visible.
+                    xAxis: { title: "Quarters", displayTitle: true },
+                    yAxes: [{ title: "Units Sold", displayTitle: true }],
                     annotations: [{
                         type: 'line',
                         mode: 'horizontal',
@@ -1140,6 +1142,58 @@
                 }
             };
             new PureChart('periodHighlightChartCanvas', periodHighlightChartConfig);
+
+            // --- Zero Trimming Demo ---
+            const zeroTrimDemoContainer = document.createElement('div');
+            zeroTrimDemoContainer.className = 'chart-container';
+            zeroTrimDemoContainer.innerHTML = `
+                <hr style="margin-top: 40px; margin-bottom: 40px;">
+                <h2>Data Trimming with <code>showLeadingTrailingZeroes</code></h2>
+                <p>The first chart uses the default behavior (<code>showLeadingTrailingZeroes: false</code>), trimming leading/trailing zeroes. The second chart explicitly sets <code>showLeadingTrailingZeroes: true</code>.</p>
+                <h3>Default Trimming (<code>showLeadingTrailingZeroes: false</code>)</h3>
+                <canvas id="zeroTrimDefaultCanvas" width="700" height="350"></canvas>
+                <h3 style="margin-top: 30px;">No Trimming (<code>showLeadingTrailingZeroes: true</code>)</h3>
+                <canvas id="zeroTrimExplicitShowCanvas" width="700" height="350"></canvas>
+            `;
+            document.body.insertBefore(zeroTrimDemoContainer, document.querySelector('script[src="PureChart.js"]').nextSibling); // Insert before the main script
+
+            const zeroTrimData = {
+                labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul"],
+                datasets: [
+                    {
+                        label: "Product Alpha",
+                        values: [0, 0, 10, 15, 20, 0, 0],
+                        borderColor: "rgba(255, 99, 132, 1)",
+                        tension: 0.1,
+                        fill: false
+                    },
+                    {
+                        label: "Product Beta",
+                        type: 'bar',
+                        values: [0, 5, 12, 18, 0, 0, 0],
+                        backgroundColor: "rgba(54, 162, 235, 0.6)"
+                    }
+                ]
+            };
+
+            new PureChart('zeroTrimDefaultCanvas', {
+                type: 'line',
+                data: JSON.parse(JSON.stringify(zeroTrimData)), // Use a copy
+                options: {
+                    title: { text: "Zeroes Trimmed (Default)" },
+                    // showLeadingTrailingZeroes: false is default
+                }
+            });
+
+            new PureChart('zeroTrimExplicitShowCanvas', {
+                type: 'line',
+                data: JSON.parse(JSON.stringify(zeroTrimData)), // Use a copy
+                options: {
+                    title: { text: "Zeroes Shown (showLeadingTrailingZeroes: true)" },
+                    showLeadingTrailingZeroes: true
+                }
+            });
+
         });
     </script>
 </body>


### PR DESCRIPTION
…ures

- Updated PureChart/README.md to document:
  - Default true display for X/Y axes in bar/line charts.
  - The new `showLeadingTrailingZeroes` option.
- Updated PureChart/demo.html:
  - Added comments to clarify default axis display.
  - Ensured zero trimming tests are clear.
- Updated PureChart/demo_full.html:
  - Added example for default axis display.
  - Added new section with examples for `showLeadingTrailingZeroes`.