### PR TITLE
Fix: Correct variable name for original dataset index in _drawLineChart

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -2435,9 +2435,9 @@ class PureChart {
                         let pointFillColorOption = ds.pointColor;
                         if (pointFillColorOption === undefined) {
                             if (ds.fill && ds.backgroundColor) {
-                                pointFillColorOption = ds.borderColor || this.activePalette.defaultDatasetColors[originalDsIndex % this.activePalette.defaultDatasetColors.length];
+                                pointFillColorOption = ds.borderColor || this.activePalette.defaultDatasetColors[originalDsIndexToUse % this.activePalette.defaultDatasetColors.length];
                             } else {
-                                pointFillColorOption = ds.backgroundColor || ds.borderColor || this.activePalette.defaultDatasetColors[originalDsIndex % this.activePalette.defaultDatasetColors.length];
+                                pointFillColorOption = ds.backgroundColor || ds.borderColor || this.activePalette.defaultDatasetColors[originalDsIndexToUse % this.activePalette.defaultDatasetColors.length];
                             }
                         }
                         this.ctx.fillStyle = this._resolveColor(pointFillColorOption, pointRect);


### PR DESCRIPTION
Resolved a `ReferenceError: originalDsIndex is not defined` within the `_drawLineChart` method. Two instances related to determining the fallback `pointFillColorOption` were incorrectly using `originalDsIndex` instead of the correctly scoped `originalDsIndexToUse`.

This change ensures that the correct variable is used, preventing the error and ensuring proper point color resolution based on the dataset's original index when falling back to theme palette colors.