### PR TITLE
Fix: Ensure pre-existing tooltips are removed on canvas replacement

### DIFF
--- a/PureChart/PureChart.js
+++ b/PureChart/PureChart.js
@@ -63,7 +63,16 @@ class PureChart {
         let canvas = document.getElementById(elementId);
 
         if (canvas && canvas.tagName === 'CANVAS') {
-            // Canvas with the given ID already exists. Remove it and create a new one.
+            // Canvas with the given ID already exists.
+            // First, remove any existing tooltip associated with this elementId.
+            const existingTooltips = document.querySelectorAll(`.purechart-tooltip[data-purechart-canvas-id="${elementId}"]`);
+            existingTooltips.forEach(tt => {
+                if (tt.parentNode) {
+                    tt.parentNode.removeChild(tt);
+                }
+            });
+
+            // Now, proceed to replace the canvas element itself.
             const parent = canvas.parentNode;
             const nextSibling = canvas.nextSibling;
 
@@ -1045,6 +1054,13 @@ class PureChart {
         this.tooltipElement = document.createElement('div');
         this.tooltipElement.style.position = 'absolute'; this.tooltipElement.style.visibility = 'hidden';
         this.tooltipElement.style.pointerEvents = 'none'; this.tooltipElement.style.zIndex = '100'; // High z-index
+
+        // Add class and data attribute for identification
+        this.tooltipElement.classList.add('purechart-tooltip');
+        if (this.canvas && this.canvas.id) {
+            this.tooltipElement.setAttribute('data-purechart-canvas-id', this.canvas.id);
+        }
+
         // Apply styles from config
         const tO = this.config.options.tooltip;
         this.tooltipElement.style.backgroundColor = tO.backgroundColor; this.tooltipElement.style.color = tO.color;


### PR DESCRIPTION
When a PureChart instance is created for an element ID that already hosts a canvas (which is then replaced), this change ensures that any tooltip associated with the old canvas is also removed.

- Tooltips are now created with a 'purechart-tooltip' class and a 'data-purechart-canvas-id' attribute.
- The constructor, when replacing a canvas, now queries for and removes only the tooltip specifically associated with that canvas ID, preventing unintended removal of tooltips from other chart instances.