### PR TITLE
feat(Mindmap): Implement manual connector drawing

### DIFF
--- a/Mindmap/mindmap.css
+++ b/Mindmap/mindmap.css
@@ -15,6 +15,15 @@
     background-color: red;
     border-radius: 50%;
     transform: translate(-50%, -50%);
+    display: none; /* Hide by default */
+}
+
+.connection-point.visible {
+    display: block; /* Show when connected */
+}
+
+.connection-point.selected {
+    background-color: blue !important;
 }
 
 .connection-point-top {


### PR DESCRIPTION
- Added the ability to manually draw and erase connectors between nodes.
- Connectors are now drawn by clicking on two connection points.
- Connectors can be erased by right-clicking on them.
- Connection points are now only visible when a connector is attached.
- The color of the connector now matches the border color of the parent node.